### PR TITLE
Add ingestion documentation with upstream OTel links and mermaid support

### DIFF
--- a/starlight-docs/astro.config.mjs
+++ b/starlight-docs/astro.config.mjs
@@ -1,12 +1,16 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import mermaid from 'astro-mermaid';
 
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://anirudha.github.io',
 	base: '/opensearch-agentops-website/docs',
 	integrations: [
+		mermaid({
+			autoTheme: true,
+		}),
 		starlight({
 			title: 'OpenSearch - Observability Stack',
 			logo: {

--- a/starlight-docs/package-lock.json
+++ b/starlight-docs/package-lock.json
@@ -10,7 +10,22 @@
       "dependencies": {
         "@astrojs/starlight": "^0.37.4",
         "astro": "^5.6.1",
+        "astro-mermaid": "^1.3.1",
+        "mermaid": "^11.12.3",
         "sharp": "^0.34.2"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -216,6 +231,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
@@ -227,6 +248,45 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
+      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
+      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
+      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
+      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@ctrl/tinycolor": {
       "version": "4.2.0",
@@ -706,6 +766,23 @@
       "license": "MIT",
       "dependencies": {
         "@expressive-code/core": "^0.41.6"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
       }
     },
     "node_modules/@img/colour": {
@@ -1214,6 +1291,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.0.tgz",
+      "integrity": "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@oslojs/encoding": {
@@ -1726,6 +1812,259 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1749,6 +2088,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -1812,6 +2157,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2083,6 +2435,27 @@
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
       }
     },
+    "node_modules/astro-mermaid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/astro-mermaid/-/astro-mermaid-1.3.1.tgz",
+      "integrity": "sha512-1+FjwayMSZLtFd+ofdu1+v8a902nN5wmPmjY2qb8tLiO96YlL65LbskiuUcyH6q9h0CdZCrkc5FimlaHZsMJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "import-meta-resolve": "^4.2.0",
+        "mdast-util-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@mermaid-js/layout-elk": "^0.2.0",
+        "astro": "^4.0.0 || ^5.0.0",
+        "mermaid": "^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mermaid-js/layout-elk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2235,6 +2608,32 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
+      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.1.2",
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/regexp-to-ast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "@chevrotain/utils": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^11.0.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -2321,6 +2720,12 @@
       "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "license": "ISC"
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -2339,6 +2744,15 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/crossws": {
       "version": "0.3.5",
@@ -2451,6 +2865,520 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
+      "integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2486,6 +3414,15 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -2621,6 +3558,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -2965,6 +3911,12 @@
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
       }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
     },
     "node_modules/hast-util-embedded": {
       "version": "3.0.0",
@@ -3386,6 +4338,18 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -3401,6 +4365,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -3536,6 +4509,36 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.33",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.33.tgz",
+      "integrity": "sha512-q3N5u+1sY9Bu7T4nlXoiRBXWfwSefNGoKeOwekV+gw0cAXQlz2Ww6BLcmBxVDeXBMUDQv6fK5bcNaJLxob3ZQA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3553,6 +4556,35 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/langium": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "~11.1.1",
+        "chevrotain-allstar": "~0.3.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3613,6 +4645,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -3943,6 +4987,34 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mermaid": {
+      "version": "11.12.3",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz",
+      "integrity": "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.1",
+        "@mermaid-js/parser": "^1.0.0",
+        "@types/d3": "^7.4.3",
+        "cytoscape": "^3.29.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.13",
+        "dayjs": "^1.11.18",
+        "dompurify": "^3.2.5",
+        "katex": "^0.16.22",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.2.1",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -4680,6 +5752,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -4923,6 +6007,18 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4945,6 +6041,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -5426,6 +6549,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.56.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
@@ -5469,6 +6598,30 @@
         "@rollup/rollup-win32-x64-msvc": "4.56.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.4.4",
@@ -5692,6 +6845,12 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/svgo": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
@@ -5766,6 +6925,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tsconfck": {
@@ -6113,6 +7281,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -6247,6 +7428,55 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",

--- a/starlight-docs/package.json
+++ b/starlight-docs/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@astrojs/starlight": "^0.37.4",
     "astro": "^5.6.1",
+    "astro-mermaid": "^1.3.1",
+    "mermaid": "^11.12.3",
     "sharp": "^0.34.2"
   }
 }

--- a/starlight-docs/src/content/docs/send-data/applications/browser.md
+++ b/starlight-docs/src/content/docs/send-data/applications/browser.md
@@ -1,12 +1,261 @@
 ---
 title: "Browser / Frontend"
-description: "Real user monitoring with OpenTelemetry for web"
+description: "Add real user monitoring to web applications with OpenTelemetry for browser-side traces and metrics"
 ---
 
-# Browser / Frontend
+This guide covers adding OpenTelemetry instrumentation to browser and frontend applications for real user monitoring (RUM). Browser instrumentation captures page loads, user interactions, fetch/XHR requests, and web vitals from end-user browsers.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- Modern browser environment (Chrome, Firefox, Safari, Edge)
+- OTel Collector running at `localhost:4318` (HTTP) -- browsers cannot use gRPC
+- npm, yarn, or pnpm for package management
+- CORS configured on the Collector to accept requests from your application origin
 
-Documentation for Browser / Frontend will be added here.
+:::tip[Upstream documentation]
+For comprehensive API reference and advanced usage, see the [OpenTelemetry JavaScript browser libraries documentation](https://opentelemetry.io/docs/languages/js/libraries/#browser).
+:::
+
+## Install dependencies
+
+```bash
+npm install @opentelemetry/api \
+  @opentelemetry/sdk-trace-web \
+  @opentelemetry/sdk-trace-base \
+  @opentelemetry/resources \
+  @opentelemetry/semantic-conventions \
+  @opentelemetry/exporter-trace-otlp-http \
+  @opentelemetry/context-zone \
+  @opentelemetry/instrumentation-document-load \
+  @opentelemetry/instrumentation-fetch \
+  @opentelemetry/instrumentation-xml-http-request
+```
+
+## SDK setup
+
+Initialize the OTel SDK early in your application entry point:
+
+```javascript
+import { WebTracerProvider } from "@opentelemetry/sdk-trace-web";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { Resource } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { ZoneContextManager } from "@opentelemetry/context-zone";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { DocumentLoadInstrumentation } from "@opentelemetry/instrumentation-document-load";
+import { FetchInstrumentation } from "@opentelemetry/instrumentation-fetch";
+import { XMLHttpRequestInstrumentation } from "@opentelemetry/instrumentation-xml-http-request";
+
+const resource = new Resource({
+  [ATTR_SERVICE_NAME]: "my-frontend",
+  "deployment.environment": "production",
+  "browser.language": navigator.language,
+});
+
+const provider = new WebTracerProvider({
+  resource,
+});
+
+provider.addSpanProcessor(
+  new BatchSpanProcessor(
+    new OTLPTraceExporter({
+      url: "http://localhost:4318/v1/traces",
+    })
+  )
+);
+
+provider.register({
+  contextManager: new ZoneContextManager(),
+});
+
+registerInstrumentations({
+  instrumentations: [
+    new DocumentLoadInstrumentation(),
+    new FetchInstrumentation({
+      propagateTraceHeaderCorsUrls: [/localhost/, /api\.example\.com/],
+    }),
+    new XMLHttpRequestInstrumentation({
+      propagateTraceHeaderCorsUrls: [/localhost/, /api\.example\.com/],
+    }),
+  ],
+});
+```
+
+## What gets captured
+
+### Document load instrumentation
+
+Automatically creates spans for the page load lifecycle:
+
+| Span | Description |
+|------|-------------|
+| `documentFetch` | Initial HTML document fetch |
+| `documentLoad` | Full page load including subresources |
+| `resourceFetch` | Individual resource loads (scripts, stylesheets, images) |
+
+Captured attributes include Navigation Timing API metrics: `domContentLoadedEventEnd`, `loadEventEnd`, `responseEnd`, etc.
+
+### Fetch / XHR instrumentation
+
+Captures outbound HTTP requests from the browser:
+
+- Request method, URL, status code
+- Request and response content length
+- Distributed trace context propagation to backends
+
+## Manual instrumentation
+
+### Creating spans for user interactions
+
+```javascript
+import { trace } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("my-frontend");
+
+function handleCheckout(cartId) {
+  const span = tracer.startSpan("checkout.click", {
+    attributes: {
+      "cart.id": cartId,
+      "cart.item_count": getCartItemCount(),
+    },
+  });
+
+  submitOrder(cartId)
+    .then((result) => {
+      span.setAttribute("order.id", result.orderId);
+      span.end();
+    })
+    .catch((err) => {
+      span.recordException(err);
+      span.setStatus({ code: 2, message: err.message });
+      span.end();
+    });
+}
+```
+
+### Tracking web vitals
+
+```javascript
+import { trace } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("web-vitals");
+
+// Using the web-vitals library
+import { onLCP, onFID, onCLS } from "web-vitals";
+
+function reportVital(metric) {
+  const span = tracer.startSpan(`web_vital.${metric.name}`, {
+    attributes: {
+      "web_vital.name": metric.name,
+      "web_vital.value": metric.value,
+      "web_vital.rating": metric.rating,
+      "web_vital.id": metric.id,
+    },
+  });
+  span.end();
+}
+
+onLCP(reportVital);
+onFID(reportVital);
+onCLS(reportVital);
+```
+
+## CORS configuration
+
+Browsers enforce CORS on requests to the Collector. Configure your OTel Collector to accept browser requests:
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:4318"
+        cors:
+          allowed_origins:
+            - "http://localhost:*"
+            - "https://myapp.example.com"
+          allowed_headers:
+            - "Content-Type"
+            - "X-Requested-With"
+          max_age: 7200
+```
+
+### Trace context propagation
+
+To connect browser traces with backend traces, configure `propagateTraceHeaderCorsUrls` in the fetch/XHR instrumentations to match your API origins. This injects `traceparent` and `tracestate` headers into outbound requests.
+
+Your backend services must also have CORS configured to accept these headers:
+
+```
+Access-Control-Allow-Headers: traceparent, tracestate
+```
+
+## Framework-specific setup
+
+### React
+
+Initialize telemetry before rendering:
+
+```javascript
+// index.js
+import "./telemetry"; // import the setup file first
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")).render(<App />);
+```
+
+### Next.js (client-side)
+
+Use a client component to initialize:
+
+```typescript
+// components/TelemetryProvider.tsx
+"use client";
+
+import { useEffect } from "react";
+
+export function TelemetryProvider({ children }) {
+  useEffect(() => {
+    import("./telemetry"); // dynamic import on client only
+  }, []);
+
+  return <>{children}</>;
+}
+```
+
+## Environment variables
+
+Browser applications cannot read environment variables at runtime. Configure these at build time or pass them through your bundler:
+
+| Build-time variable | Description | Example |
+|---------------------|-------------|---------|
+| `VITE_OTEL_ENDPOINT` | Collector HTTP endpoint | `http://localhost:4318` |
+| `VITE_OTEL_SERVICE_NAME` | Service name | `my-frontend` |
+| `NEXT_PUBLIC_OTEL_ENDPOINT` | Collector endpoint (Next.js) | `http://localhost:4318` |
+
+Example with Vite:
+
+```javascript
+const exporter = new OTLPTraceExporter({
+  url: `${import.meta.env.VITE_OTEL_ENDPOINT}/v1/traces`,
+});
+```
+
+## Limitations
+
+- **gRPC not available**: Browsers can only use HTTP/protobuf or HTTP/JSON. Export to port `4318`, not `4317`.
+- **No metrics SDK**: The `@opentelemetry/sdk-metrics` package does not yet have full browser support. Use trace-based metrics or custom span attributes.
+- **Bundle size**: The full OTel SDK adds ~50-80KB gzipped. Use tree-shaking and only import instrumentations you need.
+- **Sampling**: For high-traffic sites, configure client-side sampling to reduce Collector load.
+
+## Related links
+
+- [Applications overview](/opensearch-agentops-website/docs/send-data/applications/)
+- [OTel Collector configuration](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/)
+- [Sampling](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/)
+- [OpenTelemetry JavaScript documentation](https://opentelemetry.io/docs/languages/js/) -- Official OTel JS SDK reference
+- [Browser instrumentation libraries](https://opentelemetry.io/ecosystem/registry/?language=js&component=instrumentation) -- Available browser instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/applications/dotnet.md
+++ b/starlight-docs/src/content/docs/send-data/applications/dotnet.md
@@ -1,12 +1,239 @@
 ---
 title: ".NET"
-description: "Instrument .NET applications with OpenTelemetry"
+description: "Instrument .NET applications with OpenTelemetry to send traces, metrics, and logs to the observability stack"
 ---
 
-# .NET
+This guide covers adding OpenTelemetry instrumentation to .NET applications. The .NET OTel SDK integrates with the standard `ILogger`, `Activity`, and `Meter` APIs, making it straightforward to add observability to ASP.NET Core and other .NET workloads.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- .NET 6.0+ (or .NET Framework 4.6.2+ with limited support)
+- OTel Collector running at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)
+- NuGet for package management
 
-Documentation for .NET will be added here.
+:::tip[Upstream documentation]
+For comprehensive API reference and advanced usage, see the [official OpenTelemetry .NET documentation](https://opentelemetry.io/docs/languages/dotnet/).
+:::
+
+## Install dependencies
+
+```bash
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+```
+
+## SDK setup
+
+Configure OpenTelemetry in your `Program.cs`:
+
+```csharp
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Logs;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var resourceBuilder = ResourceBuilder.CreateDefault()
+    .AddService(
+        serviceName: "my-dotnet-service",
+        serviceVersion: "1.0.0")
+    .AddAttributes(new Dictionary<string, object>
+    {
+        ["deployment.environment"] = "development"
+    });
+
+// Traces
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService("my-dotnet-service", "1.0.0"))
+    .WithTracing(tracing => tracing
+        .SetResourceBuilder(resourceBuilder)
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddOtlpExporter(opts =>
+        {
+            opts.Endpoint = new Uri("http://localhost:4317");
+        }))
+    .WithMetrics(metrics => metrics
+        .SetResourceBuilder(resourceBuilder)
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddRuntimeInstrumentation()
+        .AddOtlpExporter(opts =>
+        {
+            opts.Endpoint = new Uri("http://localhost:4317");
+        }));
+
+// Logs
+builder.Logging.AddOpenTelemetry(logging =>
+{
+    logging.SetResourceBuilder(resourceBuilder);
+    logging.AddOtlpExporter(opts =>
+    {
+        opts.Endpoint = new Uri("http://localhost:4317");
+    });
+});
+
+var app = builder.Build();
+app.Run();
+```
+
+## Auto-instrumentation
+
+.NET supports zero-code instrumentation using the `DOTNET_STARTUP_HOOKS` environment variable:
+
+```bash
+# Download the auto-instrumentation package
+curl -L -o otel-dotnet-install.sh \
+  https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/otel-dotnet-auto-install.sh
+chmod +x otel-dotnet-install.sh
+./otel-dotnet-install.sh
+
+# Set environment variables
+export CORECLR_ENABLE_PROFILING=1
+export CORECLR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
+export CORECLR_PROFILER_PATH="$HOME/.otel-dotnet-auto/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
+export DOTNET_ADDITIONAL_DEPS="$HOME/.otel-dotnet-auto/AdditionalDeps"
+export DOTNET_SHARED_STORE="$HOME/.otel-dotnet-auto/store"
+export DOTNET_STARTUP_HOOKS="$HOME/.otel-dotnet-auto/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll"
+export OTEL_SERVICE_NAME="my-dotnet-service"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+
+dotnet run
+```
+
+Auto-instrumentation covers ASP.NET Core, HttpClient, SqlClient, Entity Framework Core, gRPC, and more.
+
+## Manual instrumentation
+
+### Creating spans
+
+.NET uses the `System.Diagnostics.Activity` API, which OTel maps to spans:
+
+```csharp
+using System.Diagnostics;
+
+public class OrderService
+{
+    private static readonly ActivitySource Source = new("MyApp.Orders");
+
+    public async Task ProcessOrder(string orderId)
+    {
+        using var activity = Source.StartActivity("process_order");
+        activity?.SetTag("order.id", orderId);
+
+        await ValidatePayment(orderId);
+
+        activity?.AddEvent(new ActivityEvent("order_processed",
+            tags: new ActivityTagsCollection
+            {
+                { "order.id", orderId }
+            }));
+    }
+}
+```
+
+Register the `ActivitySource` with the tracer provider:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("MyApp.Orders")
+        // ... exporters
+    );
+```
+
+### Recording metrics
+
+```csharp
+using System.Diagnostics.Metrics;
+
+public class OrderMetrics
+{
+    private static readonly Meter Meter = new("MyApp.Orders");
+    private static readonly Counter<long> RequestCounter =
+        Meter.CreateCounter<long>("http.server.request_count", "1", "Number of HTTP requests");
+    private static readonly Histogram<double> RequestDuration =
+        Meter.CreateHistogram<double>("http.server.duration", "ms", "HTTP request duration");
+
+    public void RecordRequest(string method, string route, double durationMs)
+    {
+        var tags = new TagList
+        {
+            { "http.method", method },
+            { "http.route", route }
+        };
+        RequestCounter.Add(1, tags);
+        RequestDuration.Record(durationMs, tags);
+    }
+}
+```
+
+Register the `Meter` with the meter provider:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddMeter("MyApp.Orders")
+        // ... exporters
+    );
+```
+
+## Framework integration
+
+### ASP.NET Core
+
+The `AddAspNetCoreInstrumentation()` call shown in the SDK setup section automatically captures:
+
+- Inbound HTTP request spans
+- Request/response attributes (method, status code, route)
+- Exception recording
+
+### gRPC
+
+```bash
+dotnet add package OpenTelemetry.Instrumentation.GrpcNetClient
+```
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddGrpcClientInstrumentation()
+    );
+```
+
+### Entity Framework Core
+
+```bash
+dotnet add package OpenTelemetry.Instrumentation.EntityFrameworkCore
+```
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddEntityFrameworkCoreInstrumentation()
+    );
+```
+
+## Environment variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Service name | `my-dotnet-service` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Export protocol | `grpc` |
+| `OTEL_TRACES_SAMPLER` | Sampler type | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument | `0.1` |
+| `CORECLR_ENABLE_PROFILING` | Enable CLR profiler (auto-instrumentation) | `1` |
+| `DOTNET_STARTUP_HOOKS` | Startup hook DLL path (auto-instrumentation) | Path to `.dll` |
+| `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS` | Enabled auto-instrumentations | `AspNet,HttpClient` |
+
+## Related links
+
+- [Applications overview](/opensearch-agentops-website/docs/send-data/applications/)
+- [Auto-instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/)
+- [Manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/)
+- [OpenTelemetry .NET documentation](https://opentelemetry.io/docs/languages/dotnet/) -- Official OTel .NET SDK reference
+- [.NET instrumentation libraries](https://opentelemetry.io/ecosystem/registry/?language=dotnet&component=instrumentation) -- Available auto-instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/applications/go.md
+++ b/starlight-docs/src/content/docs/send-data/applications/go.md
@@ -1,12 +1,265 @@
 ---
 title: "Go"
-description: "Instrument Go applications with OpenTelemetry"
+description: "Instrument Go applications with OpenTelemetry to send traces, metrics, and logs to the observability stack"
 ---
 
-# Go
+This guide covers adding OpenTelemetry instrumentation to Go applications. Go does not have an auto-instrumentation agent, so you instrument explicitly using the OTel SDK and middleware packages for common frameworks.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- Go 1.21+
+- OTel Collector running at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)
+- Go modules enabled
 
-Documentation for Go will be added here.
+:::tip[Upstream documentation]
+For comprehensive API reference and advanced usage, see the [official OpenTelemetry Go documentation](https://opentelemetry.io/docs/languages/go/).
+:::
+
+## Install dependencies
+
+```bash
+go get go.opentelemetry.io/otel \
+  go.opentelemetry.io/otel/sdk \
+  go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc \
+  go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc \
+  go.opentelemetry.io/otel/sdk/metric \
+  go.opentelemetry.io/otel/semconv/v1.26.0
+```
+
+## SDK setup
+
+Create a setup function that initializes trace and metric providers:
+
+```go
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+func Setup(ctx context.Context, serviceName string) (func(), error) {
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion("1.0.0"),
+			semconv.DeploymentEnvironment("development"),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Traces
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint("localhost:4317"),
+		otlptracegrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(res),
+		sdktrace.WithBatcher(traceExporter),
+	)
+	otel.SetTracerProvider(tp)
+
+	// Metrics
+	metricExporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithEndpoint("localhost:4317"),
+		otlpmetricgrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	mp := metric.NewMeterProvider(
+		metric.WithResource(res),
+		metric.WithReader(metric.NewPeriodicReader(metricExporter,
+			metric.WithInterval(2*time.Second),
+		)),
+	)
+	otel.SetMeterProvider(mp)
+
+	// Return shutdown function
+	shutdown := func() {
+		tp.Shutdown(ctx)
+		mp.Shutdown(ctx)
+	}
+	return shutdown, nil
+}
+```
+
+Call `Setup` in your `main()`:
+
+```go
+func main() {
+	ctx := context.Background()
+	shutdown, err := telemetry.Setup(ctx, "my-go-service")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer shutdown()
+
+	// ... start application
+}
+```
+
+## Manual instrumentation
+
+### Creating spans
+
+```go
+import "go.opentelemetry.io/otel"
+
+var tracer = otel.Tracer("my-module")
+
+func ProcessOrder(ctx context.Context, orderID string) error {
+	ctx, span := tracer.Start(ctx, "process_order")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("order.id", orderID))
+
+	// Child span
+	if err := validatePayment(ctx, orderID); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	span.AddEvent("order_processed", trace.WithAttributes(
+		attribute.String("order.id", orderID),
+	))
+	return nil
+}
+```
+
+### Recording metrics
+
+```go
+import "go.opentelemetry.io/otel"
+
+var meter = otel.Meter("my-module")
+
+func initMetrics() {
+	requestCounter, _ := meter.Int64Counter("http.server.request_count",
+		metric.WithDescription("Number of HTTP requests"),
+		metric.WithUnit("1"),
+	)
+
+	requestDuration, _ := meter.Float64Histogram("http.server.duration",
+		metric.WithDescription("HTTP request duration"),
+		metric.WithUnit("ms"),
+	)
+
+	// Use in handlers
+	requestCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("http.method", "GET"),
+			attribute.String("http.route", "/api/orders"),
+		),
+	)
+
+	requestDuration.Record(ctx, 45.2,
+		metric.WithAttributes(
+			attribute.String("http.method", "GET"),
+			attribute.String("http.route", "/api/orders"),
+		),
+	)
+}
+```
+
+## Framework integration
+
+### net/http
+
+Use the `otelhttp` middleware:
+
+```bash
+go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+```
+
+```go
+import "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+mux := http.NewServeMux()
+mux.HandleFunc("/orders", handleOrders)
+
+// Wrap the handler with OTel middleware
+handler := otelhttp.NewHandler(mux, "server")
+http.ListenAndServe(":8080", handler)
+```
+
+For outbound HTTP calls:
+
+```go
+client := &http.Client{
+	Transport: otelhttp.NewTransport(http.DefaultTransport),
+}
+resp, err := client.Get("https://api.example.com/data")
+```
+
+### gRPC
+
+```bash
+go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+```
+
+Server-side:
+
+```go
+import "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+
+server := grpc.NewServer(
+	grpc.StatsHandler(otelgrpc.NewServerHandler()),
+)
+```
+
+Client-side:
+
+```go
+conn, err := grpc.Dial(addr,
+	grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+)
+```
+
+### Gin
+
+```bash
+go get go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin
+```
+
+```go
+import "go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+
+r := gin.Default()
+r.Use(otelgin.Middleware("my-service"))
+```
+
+## Environment variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Service name | `my-go-service` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Export protocol | `grpc` |
+| `OTEL_TRACES_SAMPLER` | Sampler type | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument | `0.1` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes | `deployment.environment=prod` |
+
+## Related links
+
+- [Applications overview](/opensearch-agentops-website/docs/send-data/applications/)
+- [Manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/)
+- [Sampling](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/)
+- [OpenTelemetry Go documentation](https://opentelemetry.io/docs/languages/go/) -- Official OTel Go SDK reference
+- [Go instrumentation libraries](https://opentelemetry.io/ecosystem/registry/?language=go&component=instrumentation) -- Available instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/applications/index.md
+++ b/starlight-docs/src/content/docs/send-data/applications/index.md
@@ -1,12 +1,106 @@
 ---
 title: "Instrument Applications"
-description: "Add observability to your application code"
+description: "Add OpenTelemetry instrumentation to your application code to send traces, metrics, and logs to the observability stack"
 ---
 
-# Instrument Applications
+Application instrumentation is the process of adding observability signals — traces, metrics, and logs — to your application code. The OpenSearch Observability Stack uses OpenTelemetry (OTel) as its standard instrumentation framework, giving you a vendor-neutral way to collect telemetry from any language.
 
-This page is under construction. Content coming soon.
+## How it works
 
-## Overview
+Your application uses an OpenTelemetry SDK to generate telemetry data and export it to the OTel Collector running alongside your stack:
 
-Documentation for Instrument Applications will be added here.
+```
+Application (OTel SDK) → OTel Collector (localhost:4317/4318) → Data Prepper → OpenSearch
+```
+
+The Collector accepts data over two protocols:
+
+| Protocol | Port | Use case |
+|----------|------|----------|
+| gRPC | `4317` | Server-side applications (recommended) |
+| HTTP/protobuf | `4318` | Browser apps, environments where gRPC is unavailable |
+
+## Auto vs. manual instrumentation
+
+OpenTelemetry offers two approaches to instrumenting your code:
+
+### Auto-instrumentation
+
+Auto-instrumentation uses agents or require hooks to automatically capture telemetry from popular frameworks and libraries without code changes. This is the fastest way to get started.
+
+**Best for**: Getting broad coverage quickly, standard web frameworks, database clients, HTTP libraries.
+
+**Available for**: Python, Node.js, Java, .NET, Ruby, PHP.
+
+### Manual instrumentation
+
+Manual instrumentation gives you full control over what gets traced and measured. You create spans, record metrics, and emit logs explicitly in your code.
+
+**Best for**: Custom business logic, AI/ML pipelines, agent workflows, fine-grained control.
+
+**Available for**: All languages with an OpenTelemetry SDK.
+
+### Combining both
+
+Most production applications use both approaches together — auto-instrumentation for framework-level coverage and manual instrumentation for business-specific observability.
+
+:::tip[Upstream documentation]
+For a complete list of supported languages and their instrumentation status, see the [OpenTelemetry language APIs & SDKs](https://opentelemetry.io/docs/languages/).
+:::
+
+## Common environment variables
+
+All OpenTelemetry SDKs respect a standard set of environment variables. You can configure instrumentation without code changes by setting these:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Logical name of your service | `unknown_service` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint URL | `http://localhost:4317` (gRPC) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Export protocol (`grpc`, `http/protobuf`) | `grpc` |
+| `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `none`) | `otlp` |
+| `OTEL_METRICS_EXPORTER` | Metrics exporter (`otlp`, `none`) | `otlp` |
+| `OTEL_LOGS_EXPORTER` | Logs exporter (`otlp`, `none`) | `otlp` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated key=value resource attributes | — |
+| `OTEL_TRACES_SAMPLER` | Sampler type (`always_on`, `traceidratio`, `parentbased_traceidratio`) | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument (e.g., ratio `0.1`) | — |
+| `OTEL_PROPAGATORS` | Context propagation formats | `tracecontext,baggage` |
+
+Example using environment variables:
+
+```bash
+export OTEL_SERVICE_NAME="my-service"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production,service.version=2.1.0"
+```
+
+## Resource attributes
+
+Every telemetry signal includes resource attributes that identify the source. At minimum, set these:
+
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `service.name` | Name of the service | `checkout-service` |
+| `service.version` | Version of the service | `1.2.3` |
+| `deployment.environment` | Deployment environment | `production` |
+
+## Supported languages
+
+Choose your language to get started:
+
+| Language | Auto-instrumentation | Page | Upstream Docs |
+|----------|---------------------|------|---------------|
+| Python | Yes | [Python](/opensearch-agentops-website/docs/send-data/applications/python/) | [OTel Python](https://opentelemetry.io/docs/languages/python/) |
+| Node.js | Yes | [Node.js](/opensearch-agentops-website/docs/send-data/applications/nodejs/) | [OTel JS](https://opentelemetry.io/docs/languages/js/) |
+| Java | Yes | [Java](/opensearch-agentops-website/docs/send-data/applications/java/) | [OTel Java](https://opentelemetry.io/docs/languages/java/) |
+| Go | No (use middleware) | [Go](/opensearch-agentops-website/docs/send-data/applications/go/) | [OTel Go](https://opentelemetry.io/docs/languages/go/) |
+| .NET | Yes | [.NET](/opensearch-agentops-website/docs/send-data/applications/dotnet/) | [OTel .NET](https://opentelemetry.io/docs/languages/dotnet/) |
+| Ruby | Yes | [Ruby](/opensearch-agentops-website/docs/send-data/applications/ruby/) | [OTel Ruby](https://opentelemetry.io/docs/languages/ruby/) |
+| Browser / Frontend | Partial | [Browser](/opensearch-agentops-website/docs/send-data/applications/browser/) | [OTel JS](https://opentelemetry.io/docs/languages/js/) |
+
+## Related links
+
+- [OpenTelemetry overview](/opensearch-agentops-website/docs/send-data/opentelemetry/)
+- [Auto-instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/)
+- [Manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/)
+- [OTel Collector configuration](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/)
+- [OpenTelemetry Language APIs & SDKs](https://opentelemetry.io/docs/languages/) -- All supported languages and instrumentation guides

--- a/starlight-docs/src/content/docs/send-data/applications/java.md
+++ b/starlight-docs/src/content/docs/send-data/applications/java.md
@@ -1,12 +1,261 @@
 ---
 title: "Java"
-description: "Instrument Java applications with OpenTelemetry"
+description: "Instrument Java applications with OpenTelemetry to send traces, metrics, and logs to the observability stack"
 ---
 
-# Java
+This guide covers adding OpenTelemetry instrumentation to Java applications. Java offers a powerful auto-instrumentation agent that patches bytecode at runtime, covering hundreds of libraries with zero code changes.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- Java 8+ (Java 11+ recommended)
+- OTel Collector running at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)
+- Maven or Gradle for dependency management
 
-Documentation for Java will be added here.
+:::tip[Upstream documentation]
+For comprehensive API reference and advanced usage, see the [official OpenTelemetry Java documentation](https://opentelemetry.io/docs/languages/java/).
+:::
+
+## Install dependencies
+
+### Auto-instrumentation agent
+
+Download the latest Java agent JAR:
+
+```bash
+curl -L -o opentelemetry-javaagent.jar \
+  https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+```
+
+### Maven (manual instrumentation)
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-bom</artifactId>
+      <version>1.43.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-api</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-sdk</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-exporter-otlp</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+  </dependency>
+</dependencies>
+```
+
+### Gradle (manual instrumentation)
+
+```groovy
+implementation platform("io.opentelemetry:opentelemetry-bom:1.43.0")
+implementation "io.opentelemetry:opentelemetry-api"
+implementation "io.opentelemetry:opentelemetry-sdk"
+implementation "io.opentelemetry:opentelemetry-exporter-otlp"
+implementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure"
+```
+
+## Auto-instrumentation with the Java agent
+
+Attach the agent at JVM startup:
+
+```bash
+java -javaagent:opentelemetry-javaagent.jar \
+  -Dotel.service.name=my-java-service \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -jar my-application.jar
+```
+
+The agent automatically instruments:
+
+- Servlet containers (Tomcat, Jetty, Undertow)
+- Spring Boot, Spring MVC, Spring WebFlux
+- JAX-RS (Jersey, RESTEasy)
+- JDBC, Hibernate, JPA
+- gRPC, Apache HttpClient, OkHttp
+- Kafka, RabbitMQ, AWS SDK
+- And 100+ more libraries
+
+### Suppress specific instrumentations
+
+```bash
+java -javaagent:opentelemetry-javaagent.jar \
+  -Dotel.instrumentation.jdbc.enabled=false \
+  -jar my-application.jar
+```
+
+## Manual SDK setup
+
+For programmatic configuration without the agent:
+
+```java
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.ResourceAttributes;
+
+public class TelemetryConfig {
+
+    public static OpenTelemetry setup() {
+        Resource resource = Resource.getDefault()
+            .merge(Resource.create(io.opentelemetry.api.common.Attributes.of(
+                ResourceAttributes.SERVICE_NAME, "my-java-service",
+                ResourceAttributes.SERVICE_VERSION, "1.0.0"
+            )));
+
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .setResource(resource)
+            .addSpanProcessor(BatchSpanProcessor.builder(
+                OtlpGrpcSpanExporter.builder()
+                    .setEndpoint("http://localhost:4317")
+                    .build()
+            ).build())
+            .build();
+
+        SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+            .setResource(resource)
+            .registerMetricReader(PeriodicMetricReader.builder(
+                OtlpGrpcMetricExporter.builder()
+                    .setEndpoint("http://localhost:4317")
+                    .build()
+            ).build())
+            .build();
+
+        return OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .setMeterProvider(meterProvider)
+            .buildAndRegisterGlobal();
+    }
+}
+```
+
+## Manual instrumentation
+
+### Creating spans
+
+```java
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
+
+Tracer tracer = openTelemetry.getTracer("com.example.orders");
+
+public void processOrder(String orderId) {
+    Span span = tracer.spanBuilder("process_order")
+        .setAttribute("order.id", orderId)
+        .startSpan();
+
+    try (Scope scope = span.makeCurrent()) {
+        validatePayment(orderId);
+        span.addEvent("order_processed");
+    } catch (Exception e) {
+        span.recordException(e);
+        span.setStatus(StatusCode.ERROR, e.getMessage());
+        throw e;
+    } finally {
+        span.end();
+    }
+}
+```
+
+### Recording metrics
+
+```java
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+
+Meter meter = openTelemetry.getMeter("com.example.orders");
+
+LongCounter requestCounter = meter.counterBuilder("http.server.request_count")
+    .setDescription("Number of HTTP requests")
+    .setUnit("1")
+    .build();
+
+DoubleHistogram requestDuration = meter.histogramBuilder("http.server.duration")
+    .setDescription("HTTP request duration")
+    .setUnit("ms")
+    .build();
+
+public void handleRequest() {
+    requestCounter.add(1, Attributes.of(
+        AttributeKey.stringKey("http.method"), "GET",
+        AttributeKey.stringKey("http.route"), "/api/orders"
+    ));
+}
+```
+
+## Framework integration
+
+### Spring Boot
+
+With the Java agent, Spring Boot is auto-instrumented. For programmatic setup, add the Spring Boot starter:
+
+```xml
+<dependency>
+  <groupId>io.opentelemetry.instrumentation</groupId>
+  <artifactId>opentelemetry-spring-boot-starter</artifactId>
+</dependency>
+```
+
+Configure in `application.properties`:
+
+```properties
+otel.service.name=my-spring-service
+otel.exporter.otlp.endpoint=http://localhost:4317
+```
+
+### Quarkus
+
+Quarkus has built-in OTel support:
+
+```properties
+# application.properties
+quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.service.name=my-quarkus-service
+quarkus.otel.enabled=true
+```
+
+## Environment variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Service name | `my-java-service` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Export protocol | `grpc` |
+| `OTEL_TRACES_SAMPLER` | Sampler type | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument | `0.1` |
+| `OTEL_JAVAAGENT_ENABLED` | Enable/disable the agent | `true` |
+| `OTEL_INSTRUMENTATION_[NAME]_ENABLED` | Toggle specific instrumentation | `false` |
+| `JAVA_TOOL_OPTIONS` | Attach agent via env var | `-javaagent:opentelemetry-javaagent.jar` |
+
+## Related links
+
+- [Applications overview](/opensearch-agentops-website/docs/send-data/applications/)
+- [Auto-instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/)
+- [Manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/)
+- [OpenTelemetry Java documentation](https://opentelemetry.io/docs/languages/java/) -- Official OTel Java SDK reference
+- [Java instrumentation libraries](https://opentelemetry.io/ecosystem/registry/?language=java&component=instrumentation) -- Available auto-instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/applications/nodejs.md
+++ b/starlight-docs/src/content/docs/send-data/applications/nodejs.md
@@ -1,12 +1,257 @@
 ---
 title: "Node.js"
-description: "Instrument Node.js applications with OpenTelemetry"
+description: "Instrument Node.js applications with OpenTelemetry to send traces, metrics, and logs to the observability stack"
 ---
 
-# Node.js
+This guide covers adding OpenTelemetry instrumentation to Node.js applications. The Node.js OTel SDK supports auto-instrumentation for Express, Fastify, HTTP, gRPC, database clients, and many other libraries.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- Node.js 16+
+- OTel Collector running at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)
+- npm, yarn, or pnpm for package management
 
-Documentation for Node.js will be added here.
+:::tip[Upstream documentation]
+For comprehensive API reference and advanced usage, see the [official OpenTelemetry JavaScript documentation](https://opentelemetry.io/docs/languages/js/).
+:::
+
+## Install dependencies
+
+Install the core SDK and OTLP exporter:
+
+```bash
+npm install @opentelemetry/sdk-node \
+  @opentelemetry/api \
+  @opentelemetry/exporter-trace-otlp-grpc \
+  @opentelemetry/exporter-metrics-otlp-grpc \
+  @opentelemetry/exporter-logs-otlp-grpc \
+  @opentelemetry/resources \
+  @opentelemetry/semantic-conventions
+```
+
+For auto-instrumentation of common libraries:
+
+```bash
+npm install @opentelemetry/auto-instrumentations-node
+```
+
+## SDK setup
+
+Create a `tracing.js` (or `tracing.ts`) file that initializes the SDK:
+
+```javascript
+const { NodeSDK } = require("@opentelemetry/sdk-node");
+const {
+  OTLPTraceExporter,
+} = require("@opentelemetry/exporter-trace-otlp-grpc");
+const {
+  OTLPMetricExporter,
+} = require("@opentelemetry/exporter-metrics-otlp-grpc");
+const {
+  OTLPLogExporter,
+} = require("@opentelemetry/exporter-logs-otlp-grpc");
+const {
+  PeriodicExportingMetricReader,
+} = require("@opentelemetry/sdk-metrics");
+const { Resource } = require("@opentelemetry/resources");
+const {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+} = require("@opentelemetry/semantic-conventions");
+const {
+  getNodeAutoInstrumentations,
+} = require("@opentelemetry/auto-instrumentations-node");
+
+const resource = new Resource({
+  [ATTR_SERVICE_NAME]: "my-node-service",
+  [ATTR_SERVICE_VERSION]: "1.0.0",
+  "deployment.environment": "development",
+});
+
+const sdk = new NodeSDK({
+  resource,
+  traceExporter: new OTLPTraceExporter({
+    url: "grpc://localhost:4317",
+  }),
+  metricReader: new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter({
+      url: "grpc://localhost:4317",
+    }),
+    exportIntervalMillis: 2000,
+  }),
+  logRecordExporter: new OTLPLogExporter({
+    url: "grpc://localhost:4317",
+  }),
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+sdk.start();
+
+process.on("SIGTERM", () => {
+  sdk.shutdown().then(() => process.exit(0));
+});
+```
+
+## Auto-instrumentation
+
+The simplest approach uses `--require` to load the tracing setup before your application:
+
+```bash
+node --require ./tracing.js app.js
+```
+
+The `@opentelemetry/auto-instrumentations-node` package automatically instruments:
+
+- HTTP/HTTPS clients and servers
+- Express, Fastify, Koa, Hapi
+- gRPC clients and servers
+- MySQL, PostgreSQL, MongoDB, Redis
+- AWS SDK, GraphQL, and more
+
+To disable specific instrumentations:
+
+```javascript
+const { getNodeAutoInstrumentations } = require(
+  "@opentelemetry/auto-instrumentations-node"
+);
+
+const instrumentations = getNodeAutoInstrumentations({
+  "@opentelemetry/instrumentation-fs": { enabled: false },
+  "@opentelemetry/instrumentation-dns": { enabled: false },
+});
+```
+
+## Manual instrumentation
+
+### Creating spans
+
+```javascript
+const { trace } = require("@opentelemetry/api");
+
+const tracer = trace.getTracer("my-module");
+
+async function processOrder(orderId) {
+  return tracer.startActiveSpan("process_order", async (span) => {
+    try {
+      span.setAttribute("order.id", orderId);
+
+      // Child span
+      await tracer.startActiveSpan("validate_payment", async (child) => {
+        await validatePayment(orderId);
+        child.end();
+      });
+
+      span.addEvent("order_processed", { "order.id": orderId });
+    } catch (err) {
+      span.recordException(err);
+      span.setStatus({ code: 2, message: err.message }); // ERROR
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+```
+
+### Recording metrics
+
+```javascript
+const { metrics } = require("@opentelemetry/api");
+
+const meter = metrics.getMeter("my-module");
+
+const requestCounter = meter.createCounter("http.server.request_count", {
+  description: "Number of HTTP requests",
+  unit: "1",
+});
+
+const requestDuration = meter.createHistogram("http.server.duration", {
+  description: "HTTP request duration",
+  unit: "ms",
+});
+
+function handleRequest(req, res) {
+  requestCounter.add(1, { "http.method": req.method, "http.route": req.path });
+  const start = Date.now();
+  // ... handle request
+  requestDuration.record(Date.now() - start, {
+    "http.method": req.method,
+    "http.route": req.path,
+  });
+}
+```
+
+## Framework integration
+
+### Express
+
+```javascript
+const express = require("express");
+const {
+  ExpressInstrumentation,
+} = require("@opentelemetry/instrumentation-express");
+const {
+  HttpInstrumentation,
+} = require("@opentelemetry/instrumentation-http");
+
+// If using NodeSDK, add these to the instrumentations array:
+const sdk = new NodeSDK({
+  instrumentations: [new HttpInstrumentation(), new ExpressInstrumentation()],
+  // ... other config
+});
+
+const app = express();
+
+app.get("/orders/:id", (req, res) => {
+  res.json({ orderId: req.params.id });
+});
+
+app.listen(3000);
+```
+
+### Fastify
+
+```javascript
+const {
+  FastifyInstrumentation,
+} = require("@opentelemetry/instrumentation-fastify");
+
+const sdk = new NodeSDK({
+  instrumentations: [new FastifyInstrumentation()],
+  // ... other config
+});
+```
+
+### Next.js
+
+For Next.js applications, initialize the SDK in an `instrumentation.ts` file:
+
+```typescript
+// instrumentation.ts
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./tracing");
+  }
+}
+```
+
+## Environment variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Service name | `my-node-service` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Export protocol | `grpc` |
+| `OTEL_TRACES_SAMPLER` | Sampler type | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument | `0.1` |
+| `OTEL_NODE_ENABLED_INSTRUMENTATIONS` | Comma-separated list of instrumentations to enable | `http,express` |
+| `OTEL_NODE_DISABLED_INSTRUMENTATIONS` | Comma-separated list of instrumentations to disable | `fs,dns` |
+| `NODE_OPTIONS` | Load tracing at startup | `--require ./tracing.js` |
+
+## Related links
+
+- [Applications overview](/opensearch-agentops-website/docs/send-data/applications/)
+- [Auto-instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/)
+- [Manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/)
+- [OpenTelemetry JavaScript documentation](https://opentelemetry.io/docs/languages/js/) -- Official OTel JS/Node.js SDK reference
+- [Node.js instrumentation libraries](https://opentelemetry.io/ecosystem/registry/?language=js&component=instrumentation) -- Available auto-instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/applications/python.md
+++ b/starlight-docs/src/content/docs/send-data/applications/python.md
@@ -1,12 +1,269 @@
 ---
 title: "Python"
-description: "Instrument Python applications with OpenTelemetry"
+description: "Instrument Python applications with OpenTelemetry to send traces, metrics, and logs to the observability stack"
 ---
 
-# Python
+This guide covers adding OpenTelemetry instrumentation to Python applications. Python has mature OTel support with auto-instrumentation for popular frameworks and libraries.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- Python 3.8+
+- OTel Collector running at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)
+- pip or poetry for package management
 
-Documentation for Python will be added here.
+:::tip[Upstream documentation]
+For comprehensive API reference and advanced usage, see the [official OpenTelemetry Python documentation](https://opentelemetry.io/docs/languages/python/).
+:::
+
+## Install dependencies
+
+Install the core SDK and OTLP gRPC exporter:
+
+```bash
+pip install opentelemetry-sdk \
+  opentelemetry-exporter-otlp-proto-grpc \
+  opentelemetry-api
+```
+
+For auto-instrumentation, also install:
+
+```bash
+pip install opentelemetry-distro opentelemetry-instrumentation
+opentelemetry-bootstrap -a install
+```
+
+The `opentelemetry-bootstrap` command detects installed libraries and installs matching instrumentation packages automatically.
+
+## SDK setup
+
+Configure traces, metrics, and logs in a `setup_telemetry` function called at application startup:
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+def setup_telemetry(service_name: str = "my-service"):
+    resource = Resource.create({
+        "service.name": service_name,
+        "service.version": "1.0.0",
+        "deployment.environment": "development",
+    })
+
+    # Traces
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(endpoint="localhost:4317", insecure=True)
+        )
+    )
+    trace.set_tracer_provider(tracer_provider)
+
+    # Metrics
+    metric_reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint="localhost:4317", insecure=True),
+        export_interval_millis=2000,
+    )
+    meter_provider = MeterProvider(
+        resource=resource, metric_readers=[metric_reader]
+    )
+    metrics.set_meter_provider(meter_provider)
+
+    # Logs
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(
+        BatchLogRecordProcessor(
+            OTLPLogExporter(endpoint="localhost:4317", insecure=True)
+        )
+    )
+
+    return tracer_provider, meter_provider, logger_provider
+```
+
+Call `setup_telemetry()` before any other application code runs.
+
+## Auto-instrumentation
+
+The fastest way to instrument a Python application is with the `opentelemetry-instrument` CLI wrapper:
+
+```bash
+opentelemetry-instrument \
+  --service_name my-service \
+  --exporter_otlp_endpoint localhost:4317 \
+  --exporter_otlp_insecure true \
+  python app.py
+```
+
+This automatically patches supported libraries (requests, urllib3, Flask, Django, FastAPI, SQLAlchemy, psycopg2, redis, and more) without any code changes.
+
+To see which instrumentations are available for your installed packages:
+
+```bash
+opentelemetry-bootstrap -a requirements
+```
+
+## Manual instrumentation
+
+### Creating spans
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+def process_order(order_id: str):
+    with tracer.start_as_current_span("process_order") as span:
+        span.set_attribute("order.id", order_id)
+        span.set_attribute("order.type", "standard")
+
+        # Child span
+        with tracer.start_as_current_span("validate_payment"):
+            validate_payment(order_id)
+
+        span.add_event("order_processed", {"order.id": order_id})
+```
+
+### Recording metrics
+
+```python
+from opentelemetry import metrics
+
+meter = metrics.get_meter(__name__)
+
+request_counter = meter.create_counter(
+    name="http.server.request_count",
+    description="Number of HTTP requests",
+    unit="1",
+)
+
+request_duration = meter.create_histogram(
+    name="http.server.duration",
+    description="HTTP request duration",
+    unit="ms",
+)
+
+def handle_request():
+    request_counter.add(1, {"http.method": "GET", "http.route": "/api/orders"})
+    # ... handle request, then record duration
+    request_duration.record(45.2, {"http.method": "GET", "http.route": "/api/orders"})
+```
+
+### Emitting logs
+
+```python
+import logging
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+# Bridge Python logging to OTel
+LoggingInstrumentor().instrument(set_logging_format=True)
+
+logger = logging.getLogger(__name__)
+logger.info("Order processed", extra={"order.id": "12345"})
+```
+
+## Framework integration
+
+### FastAPI
+
+```python
+from fastapi import FastAPI
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+app = FastAPI()
+
+# Auto-instrument FastAPI
+FastAPIInstrumentor.instrument_app(app)
+
+@app.get("/orders/{order_id}")
+async def get_order(order_id: str):
+    return {"order_id": order_id}
+```
+
+Alternatively, use the ASGI middleware directly:
+
+```python
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+
+app = FastAPI()
+app = OpenTelemetryMiddleware(app)
+```
+
+### Flask
+
+```python
+from flask import Flask
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+
+app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app)
+
+@app.route("/orders/<order_id>")
+def get_order(order_id):
+    return {"order_id": order_id}
+```
+
+### Django
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    "opentelemetry.instrumentation.django",
+    # ... other apps
+]
+```
+
+Or instrument programmatically:
+
+```python
+from opentelemetry.instrumentation.django import DjangoInstrumentor
+DjangoInstrumentor().instrument()
+```
+
+## Gen-AI semantic conventions
+
+For AI/ML applications, use the OpenTelemetry semantic conventions for generative AI to capture LLM interactions:
+
+```python
+with tracer.start_as_current_span("llm.chat") as span:
+    span.set_attribute("gen_ai.system", "openai")
+    span.set_attribute("gen_ai.request.model", "gpt-4")
+    span.set_attribute("gen_ai.request.temperature", 0.7)
+    span.set_attribute("gen_ai.request.max_tokens", 1000)
+
+    response = client.chat.completions.create(...)
+
+    span.set_attribute("gen_ai.response.model", response.model)
+    span.set_attribute("gen_ai.usage.input_tokens", response.usage.prompt_tokens)
+    span.set_attribute("gen_ai.usage.output_tokens", response.usage.completion_tokens)
+```
+
+## Environment variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Service name | `my-service` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_INSECURE` | Disable TLS for gRPC | `true` |
+| `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` | Bridge Python logs to OTel | `true` |
+| `OTEL_TRACES_SAMPLER` | Sampler type | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument | `0.1` |
+| `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` | Comma-separated list of instrumentations to skip | `flask,django` |
+
+## Related links
+
+- [Applications overview](/opensearch-agentops-website/docs/send-data/applications/)
+- [Auto-instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/)
+- [Manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/)
+- [Agent traces](/opensearch-agentops-website/docs/apm/agent-traces/)
+- [OpenTelemetry Python documentation](https://opentelemetry.io/docs/languages/python/) -- Official OTel Python SDK reference
+- [Python instrumentation libraries](https://opentelemetry.io/ecosystem/registry/?language=python&component=instrumentation) -- Available auto-instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/applications/ruby.md
+++ b/starlight-docs/src/content/docs/send-data/applications/ruby.md
@@ -1,12 +1,244 @@
 ---
 title: "Ruby"
-description: "Instrument Ruby applications with OpenTelemetry"
+description: "Instrument Ruby applications with OpenTelemetry to send traces, metrics, and logs to the observability stack"
 ---
 
-# Ruby
+This guide covers adding OpenTelemetry instrumentation to Ruby applications. Ruby has auto-instrumentation support for Rails, Sinatra, Rack, and popular database and HTTP client libraries.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- Ruby 3.0+
+- OTel Collector running at `localhost:4317` (gRPC) or `localhost:4318` (HTTP)
+- Bundler for dependency management
 
-Documentation for Ruby will be added here.
+:::tip[Upstream documentation]
+For comprehensive API reference and advanced usage, see the [official OpenTelemetry Ruby documentation](https://opentelemetry.io/docs/languages/ruby/).
+:::
+
+## Install dependencies
+
+Add to your `Gemfile`:
+
+```ruby
+gem "opentelemetry-sdk"
+gem "opentelemetry-exporter-otlp"
+gem "opentelemetry-instrumentation-all"
+```
+
+Then install:
+
+```bash
+bundle install
+```
+
+The `opentelemetry-instrumentation-all` meta-gem includes instrumentation for Rails, Sinatra, Rack, Faraday, Net::HTTP, pg, mysql2, redis, sidekiq, and more.
+
+For a minimal install, pick individual instrumentation gems:
+
+```ruby
+gem "opentelemetry-sdk"
+gem "opentelemetry-exporter-otlp"
+gem "opentelemetry-instrumentation-rack"
+gem "opentelemetry-instrumentation-rails"
+```
+
+## SDK setup
+
+Initialize OpenTelemetry early in your application startup:
+
+```ruby
+require "opentelemetry/sdk"
+require "opentelemetry/exporter/otlp"
+require "opentelemetry/instrumentation/all"
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = "my-ruby-service"
+  c.service_version = "1.0.0"
+
+  c.resource = OpenTelemetry::SDK::Resources::Resource.create(
+    "deployment.environment" => "development"
+  )
+
+  c.add_span_processor(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      OpenTelemetry::Exporter::OTLP::Exporter.new(
+        endpoint: "http://localhost:4317"
+      )
+    )
+  )
+
+  c.use_all # Auto-instrument all installed libraries
+end
+```
+
+## Auto-instrumentation
+
+The `use_all` method shown above enables auto-instrumentation for all installed instrumentation gems. To selectively enable instrumentations:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use "OpenTelemetry::Instrumentation::Rack"
+  c.use "OpenTelemetry::Instrumentation::Rails"
+  c.use "OpenTelemetry::Instrumentation::Net::HTTP"
+  c.use "OpenTelemetry::Instrumentation::PG"
+end
+```
+
+To configure individual instrumentations:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use "OpenTelemetry::Instrumentation::Rails", {
+    enable_recognize_route: true
+  }
+  c.use "OpenTelemetry::Instrumentation::Sidekiq", {
+    span_naming: :job_class
+  }
+end
+```
+
+## Manual instrumentation
+
+### Creating spans
+
+```ruby
+tracer = OpenTelemetry.tracer_provider.tracer("my-module")
+
+def process_order(order_id)
+  tracer = OpenTelemetry.tracer_provider.tracer("my-module")
+
+  tracer.in_span("process_order", attributes: { "order.id" => order_id }) do |span|
+    validate_payment(order_id)
+
+    span.add_event("order_processed", attributes: { "order.id" => order_id })
+  end
+end
+```
+
+### Recording errors
+
+```ruby
+tracer.in_span("risky_operation") do |span|
+  begin
+    perform_operation
+  rescue StandardError => e
+    span.record_exception(e)
+    span.status = OpenTelemetry::Trace::Status.error(e.message)
+    raise
+  end
+end
+```
+
+### Recording metrics
+
+```ruby
+meter = OpenTelemetry.meter_provider.meter("my-module")
+
+request_counter = meter.create_counter(
+  "http.server.request_count",
+  description: "Number of HTTP requests",
+  unit: "1"
+)
+
+request_duration = meter.create_histogram(
+  "http.server.duration",
+  description: "HTTP request duration",
+  unit: "ms"
+)
+
+def handle_request(method, route, duration_ms)
+  attributes = { "http.method" => method, "http.route" => route }
+  request_counter.add(1, attributes: attributes)
+  request_duration.record(duration_ms, attributes: attributes)
+end
+```
+
+## Framework integration
+
+### Rails
+
+Create an initializer at `config/initializers/opentelemetry.rb`:
+
+```ruby
+require "opentelemetry/sdk"
+require "opentelemetry/exporter/otlp"
+require "opentelemetry/instrumentation/rails"
+require "opentelemetry/instrumentation/active_record"
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = "my-rails-app"
+
+  c.add_span_processor(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      OpenTelemetry::Exporter::OTLP::Exporter.new(
+        endpoint: "http://localhost:4317"
+      )
+    )
+  )
+
+  c.use "OpenTelemetry::Instrumentation::Rails"
+  c.use "OpenTelemetry::Instrumentation::ActiveRecord"
+  c.use "OpenTelemetry::Instrumentation::ActionPack"
+  c.use "OpenTelemetry::Instrumentation::ActionView"
+end
+```
+
+### Sinatra
+
+```ruby
+require "sinatra"
+require "opentelemetry/sdk"
+require "opentelemetry/exporter/otlp"
+require "opentelemetry/instrumentation/sinatra"
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = "my-sinatra-app"
+
+  c.add_span_processor(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      OpenTelemetry::Exporter::OTLP::Exporter.new(
+        endpoint: "http://localhost:4317"
+      )
+    )
+  )
+
+  c.use "OpenTelemetry::Instrumentation::Sinatra"
+end
+
+get "/orders/:id" do
+  { order_id: params[:id] }.to_json
+end
+```
+
+### Sidekiq
+
+```ruby
+require "opentelemetry/instrumentation/sidekiq"
+
+OpenTelemetry::SDK.configure do |c|
+  c.use "OpenTelemetry::Instrumentation::Sidekiq", {
+    span_naming: :job_class,
+    propagation_style: :link
+  }
+end
+```
+
+## Environment variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Service name | `my-ruby-service` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Export protocol | `grpc` |
+| `OTEL_TRACES_SAMPLER` | Sampler type | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument | `0.1` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes | `deployment.environment=prod` |
+| `OTEL_RUBY_DISABLED_INSTRUMENTATIONS` | Disabled instrumentations | `sidekiq,redis` |
+
+## Related links
+
+- [Applications overview](/opensearch-agentops-website/docs/send-data/applications/)
+- [Auto-instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/)
+- [Manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/)
+- [OpenTelemetry Ruby documentation](https://opentelemetry.io/docs/languages/ruby/) -- Official OTel Ruby SDK reference
+- [Ruby instrumentation libraries](https://opentelemetry.io/ecosystem/registry/?language=ruby&component=instrumentation) -- Available auto-instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/data-pipeline/batching.md
+++ b/starlight-docs/src/content/docs/send-data/data-pipeline/batching.md
@@ -1,12 +1,150 @@
 ---
-title: "Batching & Queuing"
-description: "Configure event batching and queuing for throughput"
+title: "Batching & Performance"
+description: "Tune batch sizes, memory limits, and worker counts for production throughput"
 ---
 
-# Batching & Queuing
+Telemetry data passes through multiple batching stages: the OTel SDK, the OTel Collector, and Data Prepper. Each stage has independent configuration that affects throughput, latency, and memory usage. Tuning these settings correctly prevents data loss and ensures stable ingestion under load.
 
-This page is under construction. Content coming soon.
+## Batching stages
 
-## Overview
+```mermaid
+flowchart LR
+    A[OTel SDK<br/>BatchSpanProcessor] -->|batch export| B[OTel Collector<br/>batch processor]
+    B -->|batch export| C[Data Prepper<br/>workers + delay]
+    C -->|bulk write| D[OpenSearch]
+```
 
-Documentation for Batching & Queuing will be added here.
+## OTel Collector batch processor
+
+The Collector's batch processor groups telemetry into larger payloads before exporting to Data Prepper:
+
+```yaml
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+  memory_limiter:
+    check_interval: 5s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+```
+
+### Batch processor settings
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `timeout` | 200ms | Maximum time to wait before sending a partial batch |
+| `send_batch_size` | 8192 | Number of spans/logs/metrics that trigger an immediate export |
+| `send_batch_max_size` | 0 (unlimited) | Hard upper limit on batch size; set to prevent oversized exports |
+
+Setting `timeout: 10s` and `send_batch_size: 1024` means the Collector exports a batch when either 1,024 items accumulate or 10 seconds elapse, whichever comes first. This balances throughput with acceptable latency.
+
+### Memory limiter settings
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `check_interval` | 0s | How often to check memory usage |
+| `limit_percentage` | 0 | Percentage of total memory that triggers throttling |
+| `spike_limit_percentage` | 0 | Additional headroom for sudden spikes |
+
+With `limit_percentage: 80` and `spike_limit_percentage: 25`, the Collector starts refusing data when memory reaches 80% and reserves 25% headroom for spikes. This prevents OOM crashes during traffic bursts.
+
+Place `memory_limiter` first in your processor pipeline so it runs before any memory-intensive operations:
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/dataprepper]
+```
+
+## Data Prepper workers and delay
+
+Each Data Prepper pipeline has independent concurrency and batching settings:
+
+```yaml
+otlp-pipeline:
+  workers: 5
+  delay: 10
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `workers` | 1 | Number of threads processing events in parallel |
+| `delay` | 3000 | Milliseconds to buffer events before processing a batch |
+
+Increasing `workers` improves throughput for CPU-bound processors. Increasing `delay` creates larger batches, which improves OpenSearch bulk indexing efficiency but adds latency.
+
+### Worker sizing guidelines
+
+| Pipeline Throughput | Recommended Workers | Delay (ms) |
+|--------------------|-------------------|------------|
+| < 1,000 events/sec | 1-2 | 3000 |
+| 1,000-10,000 events/sec | 3-5 | 1000-3000 |
+| 10,000-50,000 events/sec | 5-10 | 500-1000 |
+| > 50,000 events/sec | 10-20 | 100-500 |
+
+## SDK-side BatchSpanProcessor
+
+The OTel SDK batches spans before sending to the Collector. Tune these settings to control export frequency and memory usage in your application:
+
+```python
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+processor = BatchSpanProcessor(
+    exporter,
+    max_queue_size=2048,
+    schedule_delay_millis=5000,
+    max_export_batch_size=512,
+    export_timeout_millis=30000,
+)
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_queue_size` | 2048 | Maximum spans buffered in memory before dropping |
+| `schedule_delay_millis` | 5000 | Delay between export attempts |
+| `max_export_batch_size` | 512 | Spans per export batch |
+| `export_timeout_millis` | 30000 | Timeout for each export call |
+
+These defaults work well for most applications. Increase `max_queue_size` and `max_export_batch_size` for high-throughput services. Decrease `schedule_delay_millis` if you need lower latency from span creation to visibility.
+
+Environment variable equivalents:
+
+| Environment Variable | Parameter |
+|---------------------|-----------|
+| `OTEL_BSP_MAX_QUEUE_SIZE` | `max_queue_size` |
+| `OTEL_BSP_SCHEDULE_DELAY` | `schedule_delay_millis` |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | `max_export_batch_size` |
+| `OTEL_BSP_EXPORT_TIMEOUT` | `export_timeout_millis` |
+
+## Production recommendations
+
+| Setting | Development | Production |
+|---------|------------|------------|
+| Collector `batch.timeout` | 1s | 5-10s |
+| Collector `batch.send_batch_size` | 256 | 1024-4096 |
+| Collector `memory_limiter.limit_percentage` | 80 | 75-80 |
+| Data Prepper `workers` | 1 | 5-10 |
+| Data Prepper `delay` | 3000 | 500-2000 |
+| SDK `max_queue_size` | 2048 | 4096-8192 |
+| SDK `schedule_delay_millis` | 5000 | 2000-5000 |
+| SDK `max_export_batch_size` | 512 | 512-1024 |
+
+## Monitoring pipeline health
+
+Watch these indicators to detect batching or performance issues:
+
+- **Collector dropped spans/logs** -- Check `otelcol_processor_dropped_spans` and `otelcol_processor_dropped_log_records` metrics. Non-zero values indicate the memory limiter is active or the export queue is full.
+- **Data Prepper buffer usage** -- Monitor Data Prepper logs for `Buffer is full` warnings. Increase `workers` or reduce upstream throughput.
+- **OpenSearch indexing latency** -- High bulk indexing latency causes backpressure through the pipeline. Check `_nodes/stats` for thread pool rejections.
+- **SDK queue drops** -- The `otel.bsp.spans.dropped` metric indicates the SDK is producing spans faster than it can export them. Increase `max_queue_size` or reduce `schedule_delay_millis`.
+
+## Related links
+
+- [Data Prepper](/opensearch-agentops-website/docs/send-data/data-pipeline/data-prepper/) -- Full pipeline configuration reference.
+- [OTel Collector](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/) -- Collector deployment and configuration.
+- [Pipeline Overview](/opensearch-agentops-website/docs/send-data/data-pipeline/) -- Architecture and data flow diagram.

--- a/starlight-docs/src/content/docs/send-data/data-pipeline/data-prepper.md
+++ b/starlight-docs/src/content/docs/send-data/data-pipeline/data-prepper.md
@@ -1,12 +1,242 @@
 ---
 title: "Data Prepper"
-description: "Use Data Prepper for trace and log ingestion pipelines"
+description: "Configure Data Prepper pipelines for trace and log ingestion into OpenSearch"
 ---
 
-# Data Prepper
+Data Prepper is the pipeline engine that receives OTLP telemetry, routes events by signal type, applies processors, and writes to OpenSearch indices. The default configuration handles traces, logs, and service map generation.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- OpenSearch Observability Stack running (see [Quickstart](/opensearch-agentops-website/docs/get-started/quickstart/))
+- OTel Collector configured to export to Data Prepper on port 21890
 
-Documentation for Data Prepper will be added here.
+## Pipeline configuration
+
+The pipeline configuration file (`pipelines.yaml`) defines a directed acyclic graph of named pipelines. Each pipeline has a source, optional processors, optional routing rules, and one or more sinks.
+
+### OTLP source pipeline
+
+The entry-point pipeline receives all OTLP data and routes events by type:
+
+```yaml
+otlp-pipeline:
+  workers: 5
+  delay: 10
+  source:
+    otlp:
+      ssl: false
+      port: 21890
+  router:
+    - "LOG": '/eventType == "LOG"'
+    - "TRACE": '/eventType == "TRACE"'
+  route:
+    - LOG: [otel-logs-pipeline]
+    - TRACE: [otel-traces-pipeline]
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `workers` | Number of threads processing events in parallel |
+| `delay` | Milliseconds to wait before flushing a partial batch |
+| `source.otlp.port` | gRPC port for receiving OTLP data (default: 21890) |
+| `router` | Conditional expressions that classify events by type |
+| `route` | Maps router labels to downstream pipeline names |
+
+### Log pipeline
+
+The log pipeline receives routed log events, copies the timestamp field, and writes to the log analytics index:
+
+```yaml
+otel-logs-pipeline:
+  workers: 5
+  delay: 10
+  source:
+    pipeline:
+      name: "otlp-pipeline"
+  processor:
+    - copy_values:
+        entries:
+          - from_key: "time"
+            to_key: "@timestamp"
+  sink:
+    - opensearch:
+        hosts: ["https://opensearch:9200"]
+        username: "admin"
+        password: "${OPENSEARCH_PASSWORD}"
+        insecure: true
+        index_type: log-analytics-plain
+```
+
+The `copy_values` processor maps the OTel `time` field to the `@timestamp` field that OpenSearch log analytics expects.
+
+### Trace pipelines
+
+Traces fan out to two downstream pipelines for parallel processing:
+
+```yaml
+otel-traces-pipeline:
+  source:
+    pipeline:
+      name: "otlp-pipeline"
+  sink:
+    - pipeline:
+        name: "traces-raw-pipeline"
+    - pipeline:
+        name: "service-map-pipeline"
+```
+
+#### Raw traces pipeline
+
+Processes raw span data and writes to the trace analytics index:
+
+```yaml
+traces-raw-pipeline:
+  source:
+    pipeline:
+      name: "otel-traces-pipeline"
+  processor:
+    - otel_traces:
+  sink:
+    - opensearch:
+        hosts: ["https://opensearch:9200"]
+        username: "admin"
+        password: "${OPENSEARCH_PASSWORD}"
+        insecure: true
+        index_type: trace-analytics-plain-raw
+```
+
+The `otel_traces` processor converts OpenTelemetry span data into the document format that the OpenSearch trace analytics UI expects.
+
+#### Service map pipeline
+
+Aggregates span relationships to build a service dependency map:
+
+```yaml
+service-map-pipeline:
+  source:
+    pipeline:
+      name: "otel-traces-pipeline"
+  processor:
+    - otel_apm_service_map:
+        group_by_attributes:
+          - telemetry.sdk.language
+        window_duration: "10s"
+  route:
+    - SERVICE_MAP: [opensearch-service-map-sink]
+    - METRIC: [prometheus-service-map-sink]
+  sink:
+    - opensearch:
+        name: opensearch-service-map-sink
+        hosts: ["https://opensearch:9200"]
+        username: "admin"
+        password: "${OPENSEARCH_PASSWORD}"
+        insecure: true
+        index_type: otel-v2-apm-service-map
+    - prometheus_remote_write:
+        name: prometheus-service-map-sink
+        url: "http://prometheus:9090/api/v1/write"
+        max_events: 500
+        flush_timeout: "5s"
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `group_by_attributes` | Attributes to include as dimensions in the service map (e.g., `telemetry.sdk.language`) |
+| `window_duration` | Time window for aggregating service relationships |
+| `max_events` | Maximum events per Prometheus remote write batch |
+| `flush_timeout` | Maximum wait before flushing a partial Prometheus batch |
+
+The service map pipeline has a dual sink: it writes service relationship documents to OpenSearch for the service map UI, and exports derived metrics to Prometheus via remote write.
+
+## Enabling experimental processors
+
+Some processors like `otel_apm_service_map` and the Prometheus sink require explicit opt-in via `data-prepper-config.yaml`:
+
+```yaml
+ssl: false
+experimental:
+  enabled_plugins:
+    processor:
+      - otel_apm_service_map
+    sink:
+      - prometheus
+```
+
+## Index types reference
+
+| Index Type | Pipeline | Description |
+|-----------|----------|-------------|
+| `log-analytics-plain` | otel-logs-pipeline | Plain-text log events with `@timestamp` |
+| `trace-analytics-plain-raw` | traces-raw-pipeline | Raw span documents for trace analytics |
+| `otel-v2-apm-service-map` | service-map-pipeline | Service dependency relationships |
+
+## Adding custom processors
+
+Insert processors into the `processor` list of any pipeline. Processors execute in order.
+
+Common examples:
+
+```yaml
+# Filter events by attribute
+processor:
+  - filter:
+      condition: '/severity_text == "DEBUG"'
+      action: drop
+
+# Add a static field
+processor:
+  - add_entries:
+      entries:
+        - key: "environment"
+          value: "production"
+
+# Truncate long fields
+processor:
+  - truncate:
+      entries:
+        - source_key: "body"
+          length: 10000
+```
+
+Chain multiple processors to build a transformation pipeline:
+
+```yaml
+processor:
+  - copy_values:
+      entries:
+        - from_key: "time"
+          to_key: "@timestamp"
+  - add_entries:
+      entries:
+        - key: "cluster"
+          value: "prod-us-east-1"
+  - filter:
+      condition: '/severity_text == "DEBUG"'
+      action: drop
+```
+
+## Environment variables
+
+Use environment variable substitution to avoid hardcoding credentials:
+
+```yaml
+sink:
+  - opensearch:
+      hosts: ["${OPENSEARCH_HOSTS}"]
+      username: "${OPENSEARCH_USERNAME}"
+      password: "${OPENSEARCH_PASSWORD}"
+```
+
+Set these in your deployment environment or Docker Compose file:
+
+```bash
+export OPENSEARCH_HOSTS="https://opensearch:9200"
+export OPENSEARCH_USERNAME="admin"
+export OPENSEARCH_PASSWORD="your-secure-password"
+```
+
+## Related links
+
+- [Pipeline Overview](/opensearch-agentops-website/docs/send-data/data-pipeline/) -- Architecture and data flow diagram.
+- [Batching & Performance](/opensearch-agentops-website/docs/send-data/data-pipeline/batching/) -- Tune workers, batch sizes, and memory limits.
+- [Data Prepper processor reference](https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/processors/) -- Full list of available processors.

--- a/starlight-docs/src/content/docs/send-data/data-pipeline/index.md
+++ b/starlight-docs/src/content/docs/send-data/data-pipeline/index.md
@@ -1,12 +1,55 @@
 ---
 title: "Data Pipeline"
-description: "Configure data ingestion, transformation, and routing"
+description: "Understand how telemetry data flows from collectors through Data Prepper into OpenSearch"
 ---
 
-# Data Pipeline
+The data pipeline is the processing layer between your OpenTelemetry Collectors and OpenSearch. It handles routing, transformation, enrichment, and indexing of traces, logs, and metrics.
 
-This page is under construction. Content coming soon.
+In the default stack configuration, **Data Prepper** serves as the primary pipeline engine. It receives OTLP data from collectors, routes events by signal type, applies processors, and writes to the appropriate OpenSearch indices.
 
-## Overview
+## Architecture
 
-Documentation for Data Pipeline will be added here.
+```mermaid
+flowchart LR
+    A[OTel Collector] -->|OTLP gRPC :21890| B[Data Prepper]
+    B -->|Route: LOG| C[Log Pipeline]
+    B -->|Route: TRACE| D[Trace Pipeline]
+    C -->|copy_values processor| E[OpenSearch<br/>log-analytics-plain]
+    D --> F[Raw Traces Pipeline]
+    D --> G[Service Map Pipeline]
+    F -->|otel_traces processor| H[OpenSearch<br/>trace-analytics-plain-raw]
+    G -->|otel_apm_service_map processor| I[OpenSearch<br/>otel-v2-apm-service-map]
+    G --> J[Prometheus<br/>Remote Write]
+```
+
+## Pipeline components
+
+| Component | Role | Default Port |
+|-----------|------|-------------|
+| **OTel Collector** | Collects, batches, and exports telemetry from applications | 4317 (gRPC), 4318 (HTTP) |
+| **Data Prepper** | Routes, transforms, and indexes telemetry into OpenSearch | 21890 (OTLP source) |
+| **OpenSearch** | Stores and indexes traces, logs, and metrics | 9200 (REST API) |
+| **Prometheus** | Receives service map metrics via remote write | 9090 |
+
+## When to customize pipelines
+
+Customize the default pipeline configuration when you need to:
+
+- **Add processors** -- Enrich, filter, or transform events before indexing (e.g., add Kubernetes metadata, redact PII, parse log formats).
+- **Change routing** -- Send specific log sources to different indices or add conditional processing.
+- **Adjust performance** -- Tune worker counts, batch sizes, and delays for your throughput requirements.
+- **Add sinks** -- Export data to additional destinations beyond OpenSearch (e.g., S3, Kafka, Prometheus).
+- **Bypass the pipeline** -- Use the OpenSearch Bulk API directly for pre-processed data or simple ingestion patterns.
+
+## Pipeline subsections
+
+<ul>
+  <li><a href="/opensearch-agentops-website/docs/send-data/data-pipeline/data-prepper/">Data Prepper</a> -- Full pipeline configuration walkthrough including routing, processors, and sinks.</li>
+  <li><a href="/opensearch-agentops-website/docs/send-data/data-pipeline/ingest-api/">Ingest API</a> -- Direct ingestion via the OpenSearch Bulk API for pre-processed data.</li>
+  <li><a href="/opensearch-agentops-website/docs/send-data/data-pipeline/batching/">Batching &amp; Performance</a> -- Tune batch sizes, memory limits, and worker counts for production throughput.</li>
+</ul>
+
+## Related links
+
+- [OpenTelemetry Collector](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/) -- Configure the collector that feeds data into the pipeline.
+- [Data Prepper documentation](https://opensearch.org/docs/latest/data-prepper/) -- Official Data Prepper reference.

--- a/starlight-docs/src/content/docs/send-data/data-pipeline/ingest-api.md
+++ b/starlight-docs/src/content/docs/send-data/data-pipeline/ingest-api.md
@@ -1,12 +1,153 @@
 ---
 title: "Ingest API"
-description: "Send data directly via the REST ingest API"
+description: "Send pre-processed telemetry data directly to OpenSearch via the Bulk API"
 ---
 
-# Ingest API
+The OpenSearch Bulk API provides a direct ingestion path for sending telemetry data without going through the OTel Collector and Data Prepper pipeline. Use it when you have pre-processed data or need a lightweight integration.
 
-This page is under construction. Content coming soon.
+## When to use direct ingest
 
-## Overview
+| Scenario | Recommended approach |
+|----------|---------------------|
+| Application traces and logs via OTel SDKs | OTel Collector + Data Prepper pipeline |
+| Pre-processed or transformed data | Direct Ingest API |
+| Migrating historical data | Direct Ingest API |
+| Custom log formats from legacy systems | Direct Ingest API |
+| Infrastructure metrics from Prometheus | OTel Collector + Data Prepper pipeline |
+| One-off data imports or backfills | Direct Ingest API |
 
-Documentation for Ingest API will be added here.
+The OTel pipeline is preferred for production application telemetry because it handles batching, retries, schema transformation, and service map generation automatically. Use the Ingest API when your data is already in the correct format or when you need direct control over the indexing process.
+
+## Prerequisites
+
+- OpenSearch cluster accessible on port 9200
+- Valid credentials with write permissions to target indices
+
+## Index templates
+
+The Observability Stack uses specific index types. When ingesting directly, target the correct index pattern.
+
+| Signal | Index Pattern | Description |
+|--------|--------------|-------------|
+| Traces | `otel-v1-apm-span-*` | Raw span documents |
+| Logs | `ss4o_logs-*` | Simple Schema for Observability log documents |
+| Metrics | `ss4o_metrics-*` | Simple Schema for Observability metric documents |
+
+## Ingesting traces
+
+Send span documents to the trace analytics index:
+
+```bash
+curl -X POST "https://localhost:9200/otel-v1-apm-span-000001/_bulk" \
+  -H "Content-Type: application/x-ndjson" \
+  -u "admin:${OPENSEARCH_PASSWORD}" \
+  --insecure \
+  -d '
+{"index": {}}
+{"traceId":"abc123","spanId":"span456","traceState":"","parentSpanId":"","name":"HTTP GET /api/users","kind":"SPAN_KIND_SERVER","startTime":"2025-01-15T10:30:00Z","endTime":"2025-01-15T10:30:00.150Z","durationInNanos":150000000,"serviceName":"user-service","status.code":0,"resource.attributes.service.name":"user-service","resource.attributes.telemetry.sdk.language":"python"}
+'
+```
+
+## Ingesting logs
+
+Send log documents to the log analytics index:
+
+```bash
+curl -X POST "https://localhost:9200/ss4o_logs-application-000001/_bulk" \
+  -H "Content-Type: application/x-ndjson" \
+  -u "admin:${OPENSEARCH_PASSWORD}" \
+  --insecure \
+  -d '
+{"index": {}}
+{"@timestamp":"2025-01-15T10:30:00Z","severity_text":"ERROR","severity_number":17,"body":"Connection timeout to database host db-primary:5432","resource.attributes.service.name":"user-service","resource.attributes.host.name":"pod-abc123","attributes.error.type":"ConnectionTimeout","attributes.db.system":"postgresql"}
+'
+```
+
+## Ingesting metrics
+
+Send metric documents to the metrics index:
+
+```bash
+curl -X POST "https://localhost:9200/ss4o_metrics-application-000001/_bulk" \
+  -H "Content-Type: application/x-ndjson" \
+  -u "admin:${OPENSEARCH_PASSWORD}" \
+  --insecure \
+  -d '
+{"index": {}}
+{"@timestamp":"2025-01-15T10:30:00Z","name":"http.server.request.duration","kind":"HISTOGRAM","unit":"s","value":0.152,"resource.attributes.service.name":"user-service","attributes.http.request.method":"GET","attributes.http.route":"/api/users","attributes.http.response.status_code":200}
+'
+```
+
+## Bulk ingestion format
+
+The Bulk API expects newline-delimited JSON (NDJSON). Each operation requires two lines: an action line and a document line.
+
+```
+{"index": {"_index": "target-index"}}
+{"field1": "value1", "field2": "value2"}
+{"index": {"_index": "target-index"}}
+{"field1": "value3", "field2": "value4"}
+```
+
+Rules for the Bulk API:
+
+- Each line must be valid JSON terminated by a newline (`\n`).
+- The request body must end with a newline.
+- Do not include pretty-printed JSON -- each document must be a single line.
+- Set `Content-Type: application/x-ndjson`.
+
+## Batch size recommendations
+
+| Batch Size | Use Case |
+|-----------|----------|
+| 100-500 documents | Low-volume or latency-sensitive ingestion |
+| 500-2,000 documents | General-purpose bulk ingestion |
+| 2,000-5,000 documents | High-volume backfills and migrations |
+| 5-15 MB per request | Size-based limit (stay under 15 MB) |
+
+Monitor the response for errors. The Bulk API returns a per-document status, so partial failures are possible:
+
+```bash
+# Check for errors in bulk response
+curl -s -X POST "https://localhost:9200/_bulk" \
+  -H "Content-Type: application/x-ndjson" \
+  -u "admin:${OPENSEARCH_PASSWORD}" \
+  --insecure \
+  --data-binary @documents.ndjson | jq '.errors, .items[] | select(.index.error)'
+```
+
+## Programmatic ingestion
+
+For production workloads, use an OpenSearch client library instead of `curl`:
+
+```python
+from opensearchpy import OpenSearch, helpers
+
+client = OpenSearch(
+    hosts=["https://localhost:9200"],
+    http_auth=("admin", os.environ["OPENSEARCH_PASSWORD"]),
+    use_ssl=True,
+    verify_certs=False,
+)
+
+documents = [
+    {
+        "_index": "ss4o_logs-application-000001",
+        "_source": {
+            "@timestamp": "2025-01-15T10:30:00Z",
+            "severity_text": "ERROR",
+            "body": "Connection timeout",
+            "resource.attributes.service.name": "user-service",
+        },
+    },
+]
+
+success, errors = helpers.bulk(client, documents)
+print(f"Indexed {success} documents, {len(errors)} errors")
+```
+
+## Related links
+
+- [Pipeline Overview](/opensearch-agentops-website/docs/send-data/data-pipeline/) -- When to use pipelines vs. direct ingest.
+- [Data Prepper](/opensearch-agentops-website/docs/send-data/data-pipeline/data-prepper/) -- Pipeline-based ingestion with automatic transformation.
+- [OpenSearch Bulk API reference](https://opensearch.org/docs/latest/api-reference/document-apis/bulk/) -- Full API specification.

--- a/starlight-docs/src/content/docs/send-data/index.md
+++ b/starlight-docs/src/content/docs/send-data/index.md
@@ -1,12 +1,78 @@
 ---
 title: "Send Data"
-description: "Learn how to send telemetry data to OpenSearch Observability Stack"
+description: "Learn how to send traces, metrics, and logs to OpenSearch Observability Stack"
 ---
 
-# Send Data
+The OpenSearch Observability Stack ingests telemetry through a standards-based pipeline. Applications emit traces, metrics, and logs using OpenTelemetry, which are collected, processed, and routed to their respective storage backends.
 
-This page is under construction. Content coming soon.
+This section covers every layer of the ingestion pipeline, from instrumenting your code to configuring the collectors and processors that deliver data to OpenSearch and Prometheus.
 
-## Overview
+## Architecture
 
-Documentation for Send Data will be added here.
+The following diagram shows the end-to-end data flow from your applications to the storage and query layer:
+
+```mermaid
+flowchart LR
+    A["Application<br/>(OTel SDK)"] -->|"OTLP gRPC :4317<br/>OTLP HTTP :4318"| B["OTel Collector"]
+    B -->|"OTLP :21890"| C["Data Prepper"]
+    B -->|"OTLP HTTP :9090"| D["Prometheus"]
+    C --> E["OpenSearch"]
+    D --> F["OpenSearch<br/>Dashboards"]
+    E --> F
+```
+
+**Traces and logs** flow through the OTel Collector into Data Prepper, which processes and indexes them in OpenSearch. **Metrics** are forwarded from the OTel Collector to Prometheus via OTLP HTTP, where they are stored and queried by OpenSearch Dashboards.
+
+## Supported Protocols
+
+| Protocol | Port | Transport | Use Case |
+|----------|------|-----------|----------|
+| OTLP gRPC | 4317 | HTTP/2 + Protobuf | SDK default, highest throughput |
+| OTLP HTTP | 4318 | HTTP/1.1 + Protobuf or JSON | Browser, serverless, firewall-restricted environments |
+
+Both endpoints accept traces, metrics, and logs. CORS is enabled on the HTTP endpoint for browser-based instrumentation.
+
+## Default Endpoints
+
+| Component | Port | Protocol | Description |
+|-----------|------|----------|-------------|
+| OTel Collector (gRPC) | 4317 | OTLP gRPC | Primary telemetry ingestion |
+| OTel Collector (HTTP) | 4318 | OTLP HTTP | HTTP telemetry ingestion |
+| OTel Collector (metrics) | 8888 | Prometheus scrape | Collector self-monitoring |
+| Data Prepper | 21890 | OTLP gRPC | Trace and log processing |
+| Prometheus | 9090 | OTLP HTTP | Metrics storage |
+
+## Sections
+
+### [OpenTelemetry](/opensearch-agentops-website/docs/send-data/opentelemetry/)
+
+Core instrumentation framework. Learn about the OTel Collector configuration, auto-instrumentation for zero-code setup, manual instrumentation for custom telemetry, and sampling strategies for controlling data volume.
+
+### [Applications](/opensearch-agentops-website/docs/send-data/applications/)
+
+Language-specific guides for instrumenting your services. Covers Python, Java, Node.js, Go, .NET, and browser applications, plus dedicated guidance for AI/LLM agent observability.
+
+### [Data Pipeline](/opensearch-agentops-website/docs/send-data/pipeline/)
+
+Configure the backend processing layer. Covers Data Prepper pipelines for trace and log processing, Prometheus for metrics storage, and index management in OpenSearch.
+
+### [Infrastructure](/opensearch-agentops-website/docs/send-data/infrastructure/)
+
+Collect telemetry from your infrastructure. Covers host metrics, container monitoring, Kubernetes observability, and cloud provider integrations.
+
+## Quick Start
+
+To start sending data from any application, set two environment variables and run with auto-instrumentation:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_SERVICE_NAME="my-service"
+```
+
+Then follow the language-specific guide in the [Applications](/opensearch-agentops-website/docs/send-data/applications/) section, or jump straight to [Auto-Instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/) for zero-code setup.
+
+## Related Links
+
+- [Get Started](/opensearch-agentops-website/docs/get-started/) -- Platform overview and sandbox setup
+- [Investigate](/opensearch-agentops-website/docs/investigate/) -- Query and explore ingested data
+- [APM](/opensearch-agentops-website/docs/apm/) -- Application performance monitoring views

--- a/starlight-docs/src/content/docs/send-data/infrastructure/aws.md
+++ b/starlight-docs/src/content/docs/send-data/infrastructure/aws.md
@@ -1,12 +1,349 @@
 ---
 title: "AWS"
-description: "Integrate with AWS CloudWatch, Lambda, ECS, and EKS"
+description: "Integrate with AWS services using ADOT, CloudWatch, Lambda, ECS, and EKS"
 ---
 
-# AWS
+AWS environments can send telemetry to the OpenSearch Observability Stack using the AWS Distro for OpenTelemetry (ADOT). ADOT provides AWS-tested builds of the OpenTelemetry Collector and SDK auto-instrumentation agents, optimized for AWS services like ECS, EKS, Lambda, and EC2.
 
-This page is under construction. Content coming soon.
+## Architecture
 
-## Overview
+```mermaid
+graph LR
+    subgraph AWS
+        Lambda[Lambda + ADOT Layer]
+        ECS[ECS Tasks + ADOT Sidecar]
+        EKS[EKS Pods + ADOT DaemonSet]
+        CW[CloudWatch Logs/Metrics]
+    end
 
-Documentation for AWS will be added here.
+    subgraph Observability Stack
+        OC[OTel Collector]
+        DP[Data Prepper]
+        P[Prometheus]
+        OS[OpenSearch]
+    end
+
+    Lambda -->|OTLP| OC
+    ECS -->|OTLP| OC
+    EKS -->|OTLP| OC
+    CW -->|CloudWatch exporter| OC
+    OC -->|traces, logs| DP --> OS
+    OC -->|metrics| P
+```
+
+## Prerequisites
+
+- An AWS account with appropriate IAM permissions
+- A running OpenSearch Observability Stack accessible from your AWS VPC
+- AWS CLI v2 configured with valid credentials
+
+:::tip[Upstream documentation]
+For AWS-specific OTel guidance, see the [AWS Distro for OpenTelemetry documentation](https://aws-otel.github.io/docs/introduction) and the [OTel Lambda auto-instrumentation guide](https://opentelemetry.io/docs/faas/lambda-auto-instrument/).
+:::
+
+## AWS Distro for OpenTelemetry (ADOT)
+
+ADOT is the recommended way to collect telemetry from AWS workloads. It includes:
+
+- A custom OpenTelemetry Collector distribution with AWS-specific receivers and exporters
+- SDK auto-instrumentation layers for Lambda
+- ECS and EKS integration patterns
+
+### ADOT Collector vs upstream Collector
+
+| Feature | ADOT Collector | Upstream OTel Collector |
+|---------|---------------|------------------------|
+| AWS support | AWS-tested, production-validated | Community-supported |
+| AWS receivers | Built-in (ECS, X-Ray, CloudWatch) | Requires contrib modules |
+| Release cadence | Follows AWS release cycle | Community release cycle |
+| Configuration | Compatible with standard OTel config | Standard OTel config |
+
+Use ADOT when running on AWS managed services. Use the upstream Collector for self-managed infrastructure or multi-cloud deployments.
+
+## ECS integration
+
+Deploy the ADOT Collector as a sidecar container in your ECS task definition to collect telemetry from your application containers.
+
+### Task definition with ADOT sidecar
+
+```json
+{
+  "family": "my-app-with-otel",
+  "networkMode": "awsvpc",
+  "containerDefinitions": [
+    {
+      "name": "my-app",
+      "image": "my-app:latest",
+      "essential": true,
+      "environment": [
+        {
+          "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+          "value": "http://localhost:4318"
+        },
+        {
+          "name": "OTEL_SERVICE_NAME",
+          "value": "my-app"
+        },
+        {
+          "name": "OTEL_RESOURCE_ATTRIBUTES",
+          "value": "deployment.environment.name=production"
+        }
+      ],
+      "portMappings": [
+        { "containerPort": 8080, "protocol": "tcp" }
+      ]
+    },
+    {
+      "name": "adot-collector",
+      "image": "public.ecr.aws/aws-observability/aws-otel-collector:latest",
+      "essential": true,
+      "command": ["--config=/etc/ecs/ecs-default-config.yaml"],
+      "portMappings": [
+        { "containerPort": 4317, "protocol": "tcp" },
+        { "containerPort": 4318, "protocol": "tcp" }
+      ],
+      "environment": [
+        {
+          "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+          "value": "https://your-otel-collector.example.com:4317"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Custom ADOT Collector config for ECS
+
+Create a configuration that forwards telemetry to your Observability Stack:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  awsecscontainermetrics:
+    collection_interval: 30s
+
+processors:
+  batch:
+    timeout: 5s
+  resourcedetection:
+    detectors: [ecs, ec2]
+
+exporters:
+  otlphttp/data-prepper:
+    endpoint: https://your-data-prepper.example.com:21890
+  otlphttp/prometheus:
+    endpoint: https://your-prometheus.example.com:9090/api/v1/otlp
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [otlphttp/data-prepper]
+    metrics:
+      receivers: [otlp, awsecscontainermetrics]
+      processors: [resourcedetection, batch]
+      exporters: [otlphttp/prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [otlphttp/data-prepper]
+```
+
+## EKS integration
+
+For EKS, deploy the ADOT Collector as a DaemonSet using the AWS-provided Helm chart or the ADOT EKS add-on.
+
+### Install the ADOT add-on
+
+```bash
+aws eks create-addon \
+  --cluster-name my-cluster \
+  --addon-name adot \
+  --addon-version v0.92.1-eksbuild.1
+```
+
+### Deploy the Collector
+
+After installing the add-on, create an `OpenTelemetryCollector` custom resource:
+
+```yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: adot
+  namespace: observability
+spec:
+  mode: daemonset
+  serviceAccount: adot-collector
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch:
+        timeout: 5s
+      k8sattributes:
+        auth_type: serviceAccount
+    exporters:
+      otlphttp/data-prepper:
+        endpoint: http://data-prepper.observability.svc:21890
+      otlphttp/prometheus:
+        endpoint: http://prometheus.observability.svc:9090/api/v1/otlp
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [k8sattributes, batch]
+          exporters: [otlphttp/data-prepper]
+        metrics:
+          receivers: [otlp]
+          processors: [k8sattributes, batch]
+          exporters: [otlphttp/prometheus]
+        logs:
+          receivers: [otlp]
+          processors: [k8sattributes, batch]
+          exporters: [otlphttp/data-prepper]
+```
+
+See the [Kubernetes guide](/opensearch-agentops-website/docs/send-data/infrastructure/kubernetes/) for additional Kubernetes-specific configuration.
+
+## Lambda instrumentation
+
+Instrument AWS Lambda functions using the ADOT Lambda layer for automatic tracing and metrics collection.
+
+### Add the ADOT Lambda layer
+
+```bash
+aws lambda update-function-configuration \
+  --function-name my-function \
+  --layers arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-python-amd64-ver-1-24-0:1 \
+  --environment "Variables={
+    AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument,
+    OTEL_SERVICE_NAME=my-lambda-function,
+    OTEL_EXPORTER_OTLP_ENDPOINT=https://your-otel-collector.example.com:4318,
+    OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production
+  }"
+```
+
+### Available ADOT Lambda layers
+
+| Runtime | Layer ARN pattern |
+|---------|-------------------|
+| Python | `aws-otel-python-<arch>-ver-*` |
+| Node.js | `aws-otel-nodejs-<arch>-ver-*` |
+| Java | `aws-otel-java-agent-<arch>-ver-*` |
+| .NET | `aws-otel-dotnet-<arch>-ver-*` |
+| Collector only | `aws-otel-collector-<arch>-ver-*` |
+
+Replace `<arch>` with `amd64` or `arm64` based on your Lambda function architecture.
+
+### Lambda-specific configuration
+
+For Lambda functions, the ADOT layer ships with a built-in Collector. Configure it using the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment variable:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp:
+    endpoint: https://your-otel-collector.example.com:4318
+    compression: gzip
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp]
+```
+
+## CloudWatch integration
+
+Forward CloudWatch Logs and metrics to your Observability Stack using the CloudWatch receiver in the OTel Collector.
+
+### CloudWatch Logs subscription
+
+Create a subscription filter to forward logs to a Kinesis Data Firehose, which delivers to your OTel Collector or directly to OpenSearch:
+
+```bash
+aws logs put-subscription-filter \
+  --log-group-name /aws/lambda/my-function \
+  --filter-name otel-forward \
+  --filter-pattern "" \
+  --destination-arn arn:aws:firehose:us-east-1:123456789012:deliverystream/to-opensearch
+```
+
+### CloudWatch metrics via the Collector
+
+Add the CloudWatch receiver to your OTel Collector to scrape AWS metrics:
+
+```yaml
+receivers:
+  awscloudwatch:
+    region: us-east-1
+    poll_interval: 5m
+    metrics:
+      named:
+        - namespace: AWS/Lambda
+          metric_name: Duration
+          period: 5m
+          statistics: [Average, p99]
+          dimensions:
+            - name: FunctionName
+              value: my-function
+        - namespace: AWS/ECS
+          metric_name: CPUUtilization
+          period: 5m
+          statistics: [Average]
+```
+
+## IAM permissions
+
+The ADOT Collector requires the following IAM policy for AWS service integration:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics",
+        "ecs:ListTasks",
+        "ecs:DescribeTasks",
+        "ec2:DescribeInstances",
+        "xray:PutTraceSegments",
+        "xray:PutTelemetryRecords"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Related links
+
+- [Infrastructure Monitoring Overview](/opensearch-agentops-website/docs/send-data/infrastructure/)
+- [Kubernetes](/opensearch-agentops-website/docs/send-data/infrastructure/kubernetes/)
+- [Prometheus](/opensearch-agentops-website/docs/send-data/infrastructure/prometheus/)
+- [AWS Distro for OpenTelemetry](https://aws-otel.github.io/docs/introduction) -- Official ADOT documentation
+- [OTel Lambda auto-instrumentation](https://opentelemetry.io/docs/faas/lambda-auto-instrument/) -- Serverless instrumentation guide

--- a/starlight-docs/src/content/docs/send-data/infrastructure/docker.md
+++ b/starlight-docs/src/content/docs/send-data/infrastructure/docker.md
@@ -1,12 +1,258 @@
 ---
 title: "Docker"
-description: "Collect metrics and logs from Docker containers"
+description: "Collect metrics and logs from Docker containers using the OpenTelemetry Collector"
 ---
 
-# Docker
+The OpenSearch Observability Stack runs as a Docker Compose project and uses the OpenTelemetry Collector to gather container metrics and logs. You can use the same approach to monitor your own Docker-based applications alongside the stack.
 
-This page is under construction. Content coming soon.
+## Architecture
 
-## Overview
+```mermaid
+graph LR
+    subgraph Docker Host
+        C1[App Container 1]
+        C2[App Container 2]
+        DS[Docker Socket]
+        OC[OTel Collector]
+    end
 
-Documentation for Docker will be added here.
+    C1 -->|stdout/stderr| OC
+    C2 -->|stdout/stderr| OC
+    DS -->|container stats| OC
+    OC -->|traces, logs| DP[Data Prepper]
+    OC -->|metrics| P[Prometheus]
+    DP --> OS[OpenSearch]
+```
+
+## Prerequisites
+
+- Docker Engine 20.10 or later
+- Docker Compose v2
+- A running OpenSearch Observability Stack instance
+
+:::tip[Upstream documentation]
+For more on running the OTel Collector in Docker, see the [OTel Collector Docker deployment guide](https://opentelemetry.io/docs/collector/deployment/docker/).
+:::
+
+## Stack service reference
+
+The Observability Stack runs the following core services:
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `opensearch` | 9200 | Search and analytics engine |
+| `opensearch-dashboards` | 5601 | Visualization and dashboards UI |
+| `otel-collector` | 4317, 4318, 8888 | OpenTelemetry Collector (gRPC, HTTP, metrics) |
+| `data-prepper` | 21890 | Trace and log ingestion pipeline |
+| `prometheus` | 9090 | Metrics scraping and storage |
+
+## Collect container metrics
+
+The OTel Collector uses the Docker Stats receiver to collect container-level metrics from the Docker daemon.
+
+### Configure the Docker Stats receiver
+
+Add the following to your OTel Collector configuration:
+
+```yaml
+receivers:
+  docker_stats:
+    endpoint: unix:///var/run/docker.sock
+    collection_interval: 10s
+    timeout: 20s
+    api_version: 1.24
+    metrics:
+      container.cpu.usage.total:
+        enabled: true
+      container.memory.usage.total:
+        enabled: true
+      container.memory.usage.limit:
+        enabled: true
+      container.network.io.usage.rx_bytes:
+        enabled: true
+      container.network.io.usage.tx_bytes:
+        enabled: true
+      container.blockio.io_service_bytes_recursive.read:
+        enabled: true
+      container.blockio.io_service_bytes_recursive.write:
+        enabled: true
+```
+
+### Mount the Docker socket
+
+In your `docker-compose.yml`, mount the Docker socket into the OTel Collector container:
+
+```yaml
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "8888:8888"
+```
+
+### Exported metrics
+
+The Docker Stats receiver exports the following key metrics:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `container.cpu.usage.total` | cumulative | Total CPU time consumed |
+| `container.cpu.percent` | gauge | CPU usage percentage |
+| `container.memory.usage.total` | gauge | Current memory usage in bytes |
+| `container.memory.usage.limit` | gauge | Memory limit in bytes |
+| `container.memory.percent` | gauge | Memory usage percentage |
+| `container.network.io.usage.rx_bytes` | cumulative | Bytes received |
+| `container.network.io.usage.tx_bytes` | cumulative | Bytes transmitted |
+| `container.blockio.io_service_bytes_recursive.read` | cumulative | Bytes read from disk |
+| `container.blockio.io_service_bytes_recursive.write` | cumulative | Bytes written to disk |
+
+## Collect container logs
+
+### Configure the Filelog receiver
+
+Use the Filelog receiver to tail container log files from the Docker log directory:
+
+```yaml
+receivers:
+  filelog/docker:
+    include:
+      - /var/lib/docker/containers/*/*.log
+    include_file_path: true
+    operators:
+      - type: json_parser
+        id: docker_parser
+        timestamp:
+          parse_from: attributes.time
+          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+      - type: move
+        from: attributes.log
+        to: body
+      - type: move
+        from: attributes.stream
+        to: attributes["log.iostream"]
+```
+
+Mount the Docker log directory into the collector:
+
+```yaml
+services:
+  otel-collector:
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+```
+
+## Add your application to the stack
+
+To monitor your own application alongside the Observability Stack, add it to the same Docker Compose file or use a shared network:
+
+```yaml
+services:
+  my-app:
+    image: my-app:latest
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_SERVICE_NAME: my-app
+      OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=development
+    networks:
+      - observability
+
+networks:
+  observability:
+    external: true
+```
+
+If your application runs in a separate Compose file, create an external network and connect both projects:
+
+```bash
+# Create a shared network
+docker network create observability
+
+# Start the Observability Stack
+docker compose -f observability-stack/docker-compose.yml up -d
+
+# Start your application
+docker compose -f my-app/docker-compose.yml up -d
+```
+
+## Full collector pipeline configuration
+
+A complete OTel Collector config that collects Docker metrics and logs, then routes them to the appropriate backends:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  docker_stats:
+    endpoint: unix:///var/run/docker.sock
+    collection_interval: 10s
+  filelog/docker:
+    include:
+      - /var/lib/docker/containers/*/*.log
+    operators:
+      - type: json_parser
+        timestamp:
+          parse_from: attributes.time
+          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+  resourcedetection:
+    detectors: [docker]
+    timeout: 5s
+
+exporters:
+  otlphttp/data-prepper:
+    endpoint: http://data-prepper:21890
+  otlphttp/prometheus:
+    endpoint: http://prometheus:9090/api/v1/otlp
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, resourcedetection]
+      exporters: [otlphttp/data-prepper]
+    metrics:
+      receivers: [otlp, docker_stats]
+      processors: [batch, resourcedetection]
+      exporters: [otlphttp/prometheus]
+    logs:
+      receivers: [otlp, filelog/docker]
+      processors: [batch, resourcedetection]
+      exporters: [otlphttp/data-prepper]
+```
+
+## Verify data collection
+
+1. Check that the OTel Collector is receiving Docker stats:
+
+```bash
+curl -s http://localhost:8888/metrics | grep container_cpu
+```
+
+2. Verify metrics in Prometheus:
+
+```bash
+curl -s http://localhost:9090/api/v1/query?query=container_memory_usage_total | jq .
+```
+
+3. Check logs in OpenSearch Dashboards at `http://localhost:5601`.
+
+## Related links
+
+- [Infrastructure Monitoring Overview](/opensearch-agentops-website/docs/send-data/infrastructure/)
+- [Prometheus](/opensearch-agentops-website/docs/send-data/infrastructure/prometheus/)
+- [Kubernetes](/opensearch-agentops-website/docs/send-data/infrastructure/kubernetes/)
+- [OTel Collector Docker deployment](https://opentelemetry.io/docs/collector/deployment/docker/) -- Official Docker deployment guide
+- [Docker Stats receiver reference](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver) -- Docker Stats receiver documentation

--- a/starlight-docs/src/content/docs/send-data/infrastructure/fluentd.md
+++ b/starlight-docs/src/content/docs/send-data/infrastructure/fluentd.md
@@ -1,12 +1,384 @@
 ---
 title: "Fluentd & Fluent Bit"
-description: "Forward logs via Fluentd or Fluent Bit"
+description: "Forward logs to OpenSearch using Fluentd or Fluent Bit lightweight agents"
 ---
 
-# Fluentd & Fluent Bit
+Fluentd and Fluent Bit are open-source log forwarders that collect, process, and route log data. Fluent Bit is the lightweight alternative designed for high-throughput, resource-constrained environments like containers and edge devices. Both support the OpenSearch output plugin for direct ingestion.
 
-This page is under construction. Content coming soon.
+## Fluent Bit vs Fluentd
 
-## Overview
+| Feature | Fluent Bit | Fluentd |
+|---------|-----------|---------|
+| Language | C | Ruby + C |
+| Memory footprint | ~1 MB | ~30-40 MB |
+| Plugin ecosystem | ~100 built-in plugins | 1000+ community plugins |
+| Configuration | YAML or classic format | Ruby-like DSL |
+| Best for | Containers, edge, DaemonSets | Aggregation, complex routing |
+| OpenSearch output | Built-in | Plugin (`fluent-plugin-opensearch`) |
 
-Documentation for Fluentd & Fluent Bit will be added here.
+**Recommendation**: Use Fluent Bit for log collection at the edge or as a DaemonSet in Kubernetes. Use Fluentd as a centralized log aggregator when you need advanced routing or plugins not available in Fluent Bit.
+
+## Architecture
+
+```mermaid
+graph LR
+    subgraph Edge / Nodes
+        FB1[Fluent Bit]
+        FB2[Fluent Bit]
+    end
+
+    subgraph Aggregation
+        FD[Fluentd]
+    end
+
+    subgraph Observability Stack
+        DP[Data Prepper]
+        OS[OpenSearch]
+    end
+
+    FB1 -->|forward| FD
+    FB2 -->|forward| FD
+    FD -->|opensearch output| OS
+    FB1 -.->|direct| OS
+    DP -->|traces, logs| OS
+```
+
+## Prerequisites
+
+- Fluent Bit 3.x or Fluentd 1.x
+- Network access to OpenSearch on port 9200
+- For Kubernetes: `kubectl` and Helm 3
+
+:::tip[Upstream documentation]
+For comprehensive Fluent Bit and Fluentd documentation, see the [Fluent Bit manual](https://docs.fluentbit.io/manual) and the [Fluentd documentation](https://docs.fluentd.org).
+:::
+
+## Fluent Bit
+
+### Install Fluent Bit
+
+#### Docker
+
+```yaml
+services:
+  fluent-bit:
+    image: fluent/fluent-bit:latest
+    volumes:
+      - ./fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    ports:
+      - "2020:2020"   # Monitoring
+      - "24224:24224"  # Forward input
+```
+
+#### Kubernetes DaemonSet (Helm)
+
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
+helm repo update
+
+helm install fluent-bit fluent/fluent-bit \
+  -n observability \
+  --create-namespace \
+  -f fluent-bit-values.yaml
+```
+
+### Fluent Bit configuration
+
+Configure Fluent Bit to collect container logs and forward them to OpenSearch:
+
+```yaml
+service:
+  flush: 5
+  daemon: off
+  log_level: info
+  http_server: on
+  http_listen: 0.0.0.0
+  http_port: 2020
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: kube.*
+      path: /var/log/containers/*.log
+      parser: cri
+      mem_buf_limit: 5MB
+      skip_long_lines: on
+      refresh_interval: 10
+
+    - name: systemd
+      tag: host.systemd
+      systemd_filter: _SYSTEMD_UNIT=kubelet.service
+
+  filters:
+    - name: kubernetes
+      match: kube.*
+      merge_log: on
+      keep_log: off
+      k8s-logging.parser: on
+      k8s-logging.exclude: on
+
+    - name: modify
+      match: "*"
+      add:
+        cluster_name: my-cluster
+        environment: production
+
+  outputs:
+    - name: opensearch
+      match: "*"
+      host: opensearch
+      port: 9200
+      index: fluent-bit-logs
+      type: _doc
+      http_user: admin
+      http_passwd: admin
+      tls: on
+      tls.verify: off
+      suppress_type_name: on
+      trace_error: on
+      replace_dots: on
+      logstash_format: on
+      logstash_prefix: fluent-bit
+      retry_limit: 5
+```
+
+### Fluent Bit with Data Prepper
+
+Instead of writing directly to OpenSearch, you can forward logs to Data Prepper for unified processing with OTel data:
+
+```yaml
+pipeline:
+  outputs:
+    - name: http
+      match: "*"
+      host: data-prepper
+      port: 21890
+      uri: /log/ingest
+      format: json
+      json_date_format: iso8601
+```
+
+### Kubernetes-specific Helm values
+
+```yaml
+# fluent-bit-values.yaml
+config:
+  service: |
+    [SERVICE]
+        Flush         5
+        Log_Level     info
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+
+  inputs: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              /var/log/containers/*.log
+        Parser            cri
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
+
+  filters: |
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Merge_Log           On
+        Keep_Log            Off
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude On
+
+  outputs: |
+    [OUTPUT]
+        Name            opensearch
+        Match           *
+        Host            opensearch.observability.svc
+        Port            9200
+        Index           fluent-bit-logs
+        HTTP_User       admin
+        HTTP_Passwd     admin
+        tls             On
+        tls.verify      Off
+        Suppress_Type_Name On
+        Logstash_Format On
+        Logstash_Prefix k8s-logs
+        Retry_Limit     5
+
+tolerations:
+  - operator: Exists
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi
+```
+
+## Fluentd
+
+### Install Fluentd
+
+#### Docker
+
+```yaml
+services:
+  fluentd:
+    image: fluent/fluentd:v1.16-1
+    volumes:
+      - ./fluentd/conf:/fluentd/etc
+      - /var/log:/var/log:ro
+    ports:
+      - "24224:24224"
+      - "24224:24224/udp"
+```
+
+#### Install the OpenSearch plugin
+
+```bash
+fluent-gem install fluent-plugin-opensearch
+```
+
+### Fluentd configuration
+
+```xml
+# fluentd/conf/fluent.conf
+
+# Receive logs from Fluent Bit or Docker log driver
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+# Receive logs from files
+<source>
+  @type tail
+  path /var/log/app/*.log
+  pos_file /fluentd/log/app.log.pos
+  tag app.logs
+  <parse>
+    @type json
+    time_key timestamp
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+  </parse>
+</source>
+
+# Parse and enrich
+<filter app.**>
+  @type record_transformer
+  <record>
+    hostname "#{Socket.gethostname}"
+    environment production
+  </record>
+</filter>
+
+# Output to OpenSearch
+<match **>
+  @type opensearch
+  host opensearch
+  port 9200
+  user admin
+  password admin
+  scheme https
+  ssl_verify false
+  index_name fluentd-logs
+  logstash_format true
+  logstash_prefix fluentd
+  type_name _doc
+  include_tag_key true
+  <buffer>
+    @type file
+    path /fluentd/log/buffer
+    flush_interval 10s
+    chunk_limit_size 8m
+    total_limit_size 512m
+    retry_max_interval 30
+    retry_forever true
+  </buffer>
+</match>
+```
+
+### Multi-output routing
+
+Route different log streams to different indices:
+
+```xml
+<match app.access.**>
+  @type opensearch
+  host opensearch
+  port 9200
+  index_name access-logs
+  logstash_format true
+  logstash_prefix access
+  # ... connection settings
+</match>
+
+<match app.error.**>
+  @type opensearch
+  host opensearch
+  port 9200
+  index_name error-logs
+  logstash_format true
+  logstash_prefix errors
+  # ... connection settings
+</match>
+
+<match **>
+  @type opensearch
+  host opensearch
+  port 9200
+  index_name misc-logs
+  logstash_format true
+  logstash_prefix misc
+  # ... connection settings
+</match>
+```
+
+## When to use Fluent Bit vs Data Prepper
+
+| Consideration | Fluent Bit | Data Prepper |
+|---------------|-----------|--------------|
+| Primary protocol | File tailing, forward, syslog | OTLP, HTTP |
+| OTel integration | Limited (OTel output plugin) | Native OTLP support |
+| Trace processing | Not supported | Built-in trace analytics |
+| Log collection | Purpose-built for log collection | Supports logs via OTLP |
+| Resource usage | Very low (~1 MB) | Moderate (JVM-based) |
+| Kubernetes | Mature DaemonSet pattern | Sidecar or Deployment |
+| Best for | High-volume log forwarding | OTel-native pipelines |
+
+**Recommendation**: Use Fluent Bit when you need lightweight, high-throughput log collection, especially in Kubernetes or resource-constrained environments. Use Data Prepper when your applications emit telemetry via OpenTelemetry and you want unified trace and log processing. You can also use both together -- Fluent Bit collects logs and forwards them to Data Prepper for unified processing.
+
+## Verify log ingestion
+
+Check that logs are reaching OpenSearch:
+
+```bash
+# Count documents in the log index
+curl -s -u admin:admin -k \
+  'https://opensearch:9200/fluent-bit-*/_count' | jq .
+
+# View recent logs
+curl -s -u admin:admin -k \
+  'https://opensearch:9200/fluent-bit-*/_search?size=5&sort=@timestamp:desc' | jq '.hits.hits[]._source'
+```
+
+Check Fluent Bit health:
+
+```bash
+curl -s http://localhost:2020/api/v1/health
+curl -s http://localhost:2020/api/v1/metrics | jq .
+```
+
+## Related links
+
+- [Infrastructure Monitoring Overview](/opensearch-agentops-website/docs/send-data/infrastructure/)
+- [Logstash](/opensearch-agentops-website/docs/send-data/infrastructure/logstash/)
+- [Docker](/opensearch-agentops-website/docs/send-data/infrastructure/docker/)
+- [Kubernetes](/opensearch-agentops-website/docs/send-data/infrastructure/kubernetes/)
+- [Fluent Bit documentation](https://docs.fluentbit.io/manual) -- Official Fluent Bit manual
+- [Fluentd documentation](https://docs.fluentd.org) -- Official Fluentd reference

--- a/starlight-docs/src/content/docs/send-data/infrastructure/index.md
+++ b/starlight-docs/src/content/docs/send-data/infrastructure/index.md
@@ -1,12 +1,123 @@
 ---
-title: "Instrument Infrastructure"
-description: "Collect telemetry from your infrastructure components"
+title: "Infrastructure Monitoring"
+description: "Collect metrics, logs, and traces from your infrastructure components using OpenTelemetry"
 ---
 
-# Instrument Infrastructure
+Infrastructure monitoring gives you visibility into the health and performance of the systems that run your applications. The OpenSearch Observability Stack uses OpenTelemetry as the primary collection mechanism, with support for additional tools like Prometheus, Logstash, and Fluent Bit for specialized use cases.
 
-This page is under construction. Content coming soon.
+## Architecture overview
 
-## Overview
+The following diagram shows how infrastructure telemetry flows through the stack:
 
-Documentation for Instrument Infrastructure will be added here.
+```mermaid
+graph LR
+    subgraph Sources
+        D[Docker]
+        K[Kubernetes]
+        VM[VMs / Bare Metal]
+        CW[AWS CloudWatch]
+    end
+
+    subgraph Collection
+        OC[OTel Collector]
+        P[Prometheus]
+        FB[Fluent Bit]
+        LS[Logstash]
+    end
+
+    subgraph Pipeline
+        DP[Data Prepper]
+        OS[OpenSearch]
+        PR[Prometheus TSDB]
+    end
+
+    D --> OC
+    K --> OC
+    VM --> OC
+    CW --> OC
+    D --> FB
+    K --> FB
+    VM --> LS
+
+    OC -->|traces, logs| DP --> OS
+    OC -->|metrics OTLP| PR
+    FB --> DP
+    LS --> OS
+    P --> PR
+```
+
+## Collection strategies
+
+Choose your collection approach based on what you need to monitor:
+
+| Strategy | Best for | Telemetry types | Tool |
+|----------|----------|-----------------|------|
+| OTel Collector receivers | Container and host metrics, logs | Metrics, logs | OpenTelemetry Collector |
+| Prometheus scraping | Application and service metrics | Metrics | Prometheus |
+| Log forwarders | High-volume log collection | Logs | Fluent Bit, Fluentd, Logstash |
+| Cloud integrations | Managed cloud services | Metrics, logs, traces | ADOT, CloudWatch |
+
+### OpenTelemetry-first approach
+
+The recommended approach is to deploy the OpenTelemetry Collector as your primary collection agent. The Collector provides:
+
+- **Unified collection** of metrics, logs, and traces from a single agent
+- **Receivers** for Docker stats, Kubernetes cluster metrics, host metrics, and more
+- **Processors** for enriching data with resource attributes (hostname, container ID, pod name)
+- **Exporters** to route data to Data Prepper (traces/logs) and Prometheus (metrics)
+
+### Supplementary tools
+
+For specific use cases, you can add specialized tools alongside the OTel Collector:
+
+- **Prometheus** for scraping metrics endpoints and long-term metric storage
+- **Fluent Bit** for lightweight, high-throughput log forwarding
+- **Logstash** for complex log transformation pipelines
+- **ADOT** for AWS-native environments with managed collector support
+
+## Core infrastructure signals
+
+### Metrics
+
+Infrastructure metrics provide quantitative measurements of system health:
+
+- **Host metrics**: CPU usage, memory utilization, disk I/O, network throughput
+- **Container metrics**: Container CPU/memory limits and usage, restart counts, network stats
+- **Kubernetes metrics**: Pod status, node capacity, deployment replicas, resource requests vs limits
+- **Service metrics**: Prometheus-scraped application metrics, custom gauges and counters
+
+### Logs
+
+Infrastructure logs capture events and state changes:
+
+- **Container logs**: stdout/stderr from running containers
+- **System logs**: Syslog, journald, kernel messages
+- **Kubernetes logs**: Pod logs, kubelet logs, control plane component logs
+- **Cloud service logs**: CloudWatch Logs, ECS task logs, Lambda invocation logs
+
+### Traces
+
+Infrastructure traces are less common but useful for:
+
+- **Request routing**: Tracing requests through load balancers and proxies
+- **Service mesh**: Envoy/Istio sidecar proxy traces
+- **Cloud function invocations**: Lambda execution traces via ADOT
+
+## Prerequisites
+
+Before setting up infrastructure monitoring, ensure you have:
+
+- A running OpenSearch Observability Stack (see [Sandbox](/opensearch-agentops-website/docs/get-started/sandbox/))
+- Network access from your infrastructure to the OTel Collector endpoints (ports 4317/4318)
+- Appropriate permissions to deploy agents on your target infrastructure
+
+## Next steps
+
+Choose the guide that matches your infrastructure:
+
+- [Docker](/opensearch-agentops-website/docs/send-data/infrastructure/docker/) -- Monitor Docker containers and Compose deployments
+- [Kubernetes](/opensearch-agentops-website/docs/send-data/infrastructure/kubernetes/) -- Monitor Kubernetes clusters, pods, and workloads
+- [AWS](/opensearch-agentops-website/docs/send-data/infrastructure/aws/) -- Integrate with AWS services using ADOT
+- [Prometheus](/opensearch-agentops-website/docs/send-data/infrastructure/prometheus/) -- Scrape and store Prometheus metrics
+- [Logstash](/opensearch-agentops-website/docs/send-data/infrastructure/logstash/) -- Route logs through Logstash pipelines
+- [Fluentd & Fluent Bit](/opensearch-agentops-website/docs/send-data/infrastructure/fluentd/) -- Forward logs with lightweight agents

--- a/starlight-docs/src/content/docs/send-data/infrastructure/kubernetes.md
+++ b/starlight-docs/src/content/docs/send-data/infrastructure/kubernetes.md
@@ -1,12 +1,327 @@
 ---
 title: "Kubernetes"
-description: "Monitor Kubernetes clusters, pods, and workloads"
+description: "Monitor Kubernetes clusters, pods, and workloads with OpenTelemetry"
 ---
 
-# Kubernetes
+Kubernetes environments require a distributed collection strategy to capture cluster metrics, pod logs, and distributed traces across nodes. The OpenTelemetry Collector deployed as a DaemonSet and/or Deployment provides comprehensive Kubernetes observability.
 
-This page is under construction. Content coming soon.
+## Architecture
 
-## Overview
+```mermaid
+graph TB
+    subgraph Kubernetes Cluster
+        subgraph Node 1
+            DS1[OTel DaemonSet Pod]
+            P1[App Pod]
+            P2[App Pod]
+        end
+        subgraph Node 2
+            DS2[OTel DaemonSet Pod]
+            P3[App Pod]
+        end
+        DEP[OTel Deployment]
+    end
 
-Documentation for Kubernetes will be added here.
+    P1 -->|OTLP| DS1
+    P2 -->|OTLP| DS1
+    P3 -->|OTLP| DS2
+    DS1 -->|forward| DEP
+    DS2 -->|forward| DEP
+    DEP -->|traces, logs| DP[Data Prepper]
+    DEP -->|metrics| PR[Prometheus]
+    DP --> OS[OpenSearch]
+```
+
+## Prerequisites
+
+- Kubernetes cluster (v1.24 or later)
+- `kubectl` configured with cluster access
+- Helm 3 installed
+- Network access from the cluster to your OpenSearch Observability Stack endpoints
+
+:::tip[Upstream documentation]
+For comprehensive Kubernetes observability with OpenTelemetry, see the [OTel Kubernetes documentation](https://opentelemetry.io/docs/kubernetes/) and the [Helm chart guide](https://opentelemetry.io/docs/kubernetes/helm/).
+:::
+
+## Deployment patterns
+
+| Pattern | Use case | Collector mode |
+|---------|----------|----------------|
+| DaemonSet | Node-level metrics and pod log collection | Agent |
+| Deployment | Cluster-wide metrics, centralized processing | Gateway |
+| Sidecar | Per-pod collection with custom processing | Agent |
+
+The recommended approach combines a DaemonSet for per-node collection with a Deployment for centralized processing and export.
+
+## Install with Helm
+
+The OpenTelemetry Operator and Collector Helm charts simplify deployment on Kubernetes.
+
+### Add the Helm repository
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+```
+
+### Deploy the Collector as a DaemonSet
+
+Create a `values-daemonset.yaml` file:
+
+```yaml
+mode: daemonset
+
+presets:
+  logsCollection:
+    enabled: true
+    includeCollectorLogs: false
+  hostMetrics:
+    enabled: true
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+    extractAllPodAnnotations: false
+
+config:
+  receivers:
+    kubeletstats:
+      collection_interval: 30s
+      auth_type: serviceAccount
+      endpoint: "https://${env:K8S_NODE_NAME}:10250"
+      insecure_skip_verify: true
+      metric_groups:
+        - node
+        - pod
+        - container
+
+  processors:
+    batch:
+      timeout: 5s
+      send_batch_size: 1024
+    k8sattributes:
+      auth_type: serviceAccount
+      extract:
+        metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.job.name
+          - k8s.cronjob.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.pod.start_time
+        labels:
+          - tag_name: app.label.component
+            key: app.kubernetes.io/component
+            from: pod
+      pod_association:
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+
+  exporters:
+    otlphttp/data-prepper:
+      endpoint: http://data-prepper.observability.svc:21890
+    otlphttp/prometheus:
+      endpoint: http://prometheus.observability.svc:9090/api/v1/otlp
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [k8sattributes, batch]
+        exporters: [otlphttp/data-prepper]
+      metrics:
+        receivers: [otlp, hostmetrics, kubeletstats]
+        processors: [k8sattributes, batch]
+        exporters: [otlphttp/prometheus]
+      logs:
+        receivers: [otlp, filelog]
+        processors: [k8sattributes, batch]
+        exporters: [otlphttp/data-prepper]
+```
+
+Install the chart:
+
+```bash
+helm install otel-daemonset open-telemetry/opentelemetry-collector \
+  -f values-daemonset.yaml \
+  -n observability \
+  --create-namespace
+```
+
+### Deploy the Collector as a Deployment (gateway)
+
+For cluster-level metrics, deploy a separate Collector as a Deployment:
+
+```yaml
+mode: deployment
+replicaCount: 2
+
+config:
+  receivers:
+    k8s_cluster:
+      collection_interval: 30s
+      node_conditions_to_report:
+        - Ready
+        - MemoryPressure
+        - DiskPressure
+      allocatable_types_to_report:
+        - cpu
+        - memory
+        - storage
+    k8s_events:
+      auth_type: serviceAccount
+
+  processors:
+    batch:
+      timeout: 5s
+
+  exporters:
+    otlphttp/data-prepper:
+      endpoint: http://data-prepper.observability.svc:21890
+    otlphttp/prometheus:
+      endpoint: http://prometheus.observability.svc:9090/api/v1/otlp
+
+  service:
+    pipelines:
+      metrics:
+        receivers: [k8s_cluster]
+        processors: [batch]
+        exporters: [otlphttp/prometheus]
+      logs:
+        receivers: [k8s_events]
+        processors: [batch]
+        exporters: [otlphttp/data-prepper]
+```
+
+```bash
+helm install otel-gateway open-telemetry/opentelemetry-collector \
+  -f values-deployment.yaml \
+  -n observability
+```
+
+## Kubernetes attributes processor
+
+The `k8sattributes` processor enriches telemetry with Kubernetes metadata. This is critical for correlating metrics, logs, and traces with their source pods and deployments.
+
+### Extracted attributes
+
+| Attribute | Description |
+|-----------|-------------|
+| `k8s.namespace.name` | Namespace of the pod |
+| `k8s.pod.name` | Pod name |
+| `k8s.pod.uid` | Pod UID |
+| `k8s.node.name` | Node the pod runs on |
+| `k8s.deployment.name` | Owning Deployment name |
+| `k8s.statefulset.name` | Owning StatefulSet name |
+| `k8s.daemonset.name` | Owning DaemonSet name |
+| `k8s.container.name` | Container name within the pod |
+| `k8s.container.restart_count` | Container restart count |
+
+### RBAC requirements
+
+The Collector service account needs permissions to query the Kubernetes API. The Helm chart creates these automatically, but if deploying manually, apply:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes", "nodes/stats", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    namespace: observability
+```
+
+## Collect pod logs
+
+The DaemonSet preset `logsCollection.enabled: true` configures the Filelog receiver to tail pod logs from `/var/log/pods/`. The receiver automatically parses the CRI log format and extracts metadata.
+
+To filter logs for specific namespaces:
+
+```yaml
+config:
+  receivers:
+    filelog:
+      include:
+        - /var/log/pods/my-namespace_*/*/*.log
+      exclude:
+        - /var/log/pods/kube-system_*/*/*.log
+```
+
+## Configure application instrumentation
+
+Applications running in Kubernetes send telemetry to the DaemonSet Collector via the node-local OTLP endpoint. Set these environment variables in your application pods:
+
+```yaml
+env:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://$(K8S_NODE_NAME):4317"
+  - name: OTEL_SERVICE_NAME
+    value: "my-service"
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "k8s.namespace.name=$(K8S_NAMESPACE),k8s.pod.name=$(K8S_POD_NAME)"
+  - name: K8S_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: K8S_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+```
+
+## Verify the deployment
+
+Check that the Collector pods are running:
+
+```bash
+kubectl get pods -n observability -l app.kubernetes.io/name=opentelemetry-collector
+```
+
+View Collector logs for errors:
+
+```bash
+kubectl logs -n observability -l app.kubernetes.io/name=opentelemetry-collector --tail=50
+```
+
+Verify metrics are being collected in Prometheus:
+
+```bash
+kubectl port-forward -n observability svc/prometheus 9090:9090
+curl -s 'http://localhost:9090/api/v1/query?query=k8s_pod_cpu_utilization' | jq .
+```
+
+## Related links
+
+- [Infrastructure Monitoring Overview](/opensearch-agentops-website/docs/send-data/infrastructure/)
+- [Docker](/opensearch-agentops-website/docs/send-data/infrastructure/docker/)
+- [Prometheus](/opensearch-agentops-website/docs/send-data/infrastructure/prometheus/)
+- [OpenTelemetry Kubernetes documentation](https://opentelemetry.io/docs/kubernetes/) -- Official OTel Kubernetes guide
+- [OTel Collector Helm charts](https://opentelemetry.io/docs/kubernetes/helm/) -- Helm deployment reference

--- a/starlight-docs/src/content/docs/send-data/infrastructure/logstash.md
+++ b/starlight-docs/src/content/docs/send-data/infrastructure/logstash.md
@@ -1,12 +1,244 @@
 ---
 title: "Logstash"
-description: "Send logs and events through Logstash pipelines"
+description: "Send logs and events through Logstash pipelines to OpenSearch"
 ---
 
-# Logstash
+Logstash is a server-side data processing pipeline that ingests, transforms, and forwards logs and events. When used with the OpenSearch Observability Stack, Logstash can serve as an alternative or complement to Data Prepper for log ingestion, particularly when you need complex transformations, conditional routing, or have existing Logstash pipelines.
 
-This page is under construction. Content coming soon.
+## Architecture
 
-## Overview
+```mermaid
+graph LR
+    subgraph Sources
+        F[Filebeat]
+        S[Syslog]
+        K[Kafka]
+        H[HTTP]
+    end
 
-Documentation for Logstash will be added here.
+    subgraph Processing
+        LS[Logstash]
+    end
+
+    subgraph Observability Stack
+        OS[OpenSearch]
+        DP[Data Prepper]
+    end
+
+    F --> LS
+    S --> LS
+    K --> LS
+    H --> LS
+    LS -->|OpenSearch output| OS
+    DP -->|traces, logs| OS
+```
+
+## Prerequisites
+
+- Java 11 or later (Java 17 recommended)
+- Logstash 8.x with the OpenSearch output plugin
+- Network access to OpenSearch on port 9200
+
+:::tip[Upstream documentation]
+For more on the OpenSearch Logstash plugin, see the [OpenSearch Logstash documentation](https://opensearch.org/docs/latest/tools/logstash/index/).
+:::
+
+## Install Logstash with OpenSearch output
+
+### Install Logstash
+
+```bash
+# Download and install Logstash
+wget https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-x64.tar.gz
+tar -xzf logstash-oss-with-opensearch-output-plugin-8.9.0-linux-x64.tar.gz
+cd logstash-8.9.0
+```
+
+Or install the plugin into an existing Logstash installation:
+
+```bash
+bin/logstash-plugin install logstash-output-opensearch
+```
+
+### Docker deployment
+
+```yaml
+services:
+  logstash:
+    image: opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+    volumes:
+      - ./pipeline:/usr/share/logstash/pipeline
+      - ./config/logstash.yml:/usr/share/logstash/config/logstash.yml
+    ports:
+      - "5044:5044"    # Beats input
+      - "5000:5000"    # TCP input
+      - "9600:9600"    # Monitoring API
+    environment:
+      LS_JAVA_OPTS: "-Xmx512m -Xms512m"
+```
+
+## Pipeline configuration
+
+Logstash pipelines consist of three stages: input, filter, and output.
+
+### Basic log pipeline
+
+```ruby
+input {
+  beats {
+    port => 5044
+  }
+  tcp {
+    port => 5000
+    codec => json_lines
+  }
+}
+
+filter {
+  # Parse JSON log bodies
+  if [message] =~ /^\{/ {
+    json {
+      source => "message"
+      target => "parsed"
+    }
+  }
+
+  # Add timestamp
+  date {
+    match => ["[parsed][timestamp]", "ISO8601", "yyyy-MM-dd HH:mm:ss"]
+    target => "@timestamp"
+  }
+
+  # Add environment metadata
+  mutate {
+    add_field => {
+      "environment" => "production"
+      "pipeline" => "logstash"
+    }
+  }
+}
+
+output {
+  opensearch {
+    hosts => ["https://opensearch:9200"]
+    index => "logs-%{+YYYY.MM.dd}"
+    user => "admin"
+    password => "admin"
+    ssl_certificate_verification => false
+  }
+}
+```
+
+### Syslog ingestion
+
+```ruby
+input {
+  syslog {
+    port => 1514
+    type => "syslog"
+  }
+}
+
+filter {
+  if [type] == "syslog" {
+    grok {
+      match => {
+        "message" => "%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:hostname} %{DATA:program}(?:\[%{POSINT:pid}\])?: %{GREEDYDATA:log_message}"
+      }
+    }
+    date {
+      match => ["syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss"]
+    }
+    mutate {
+      remove_field => ["message"]
+      rename => { "log_message" => "message" }
+    }
+  }
+}
+
+output {
+  opensearch {
+    hosts => ["https://opensearch:9200"]
+    index => "syslog-%{+YYYY.MM.dd}"
+    user => "admin"
+    password => "admin"
+    ssl_certificate_verification => false
+  }
+}
+```
+
+### Conditional routing
+
+Route different log types to different indices:
+
+```ruby
+filter {
+  if [fields][log_type] == "application" {
+    mutate { add_field => { "[@metadata][target_index]" => "app-logs" } }
+  } else if [fields][log_type] == "access" {
+    mutate { add_field => { "[@metadata][target_index]" => "access-logs" } }
+  } else {
+    mutate { add_field => { "[@metadata][target_index]" => "misc-logs" } }
+  }
+}
+
+output {
+  opensearch {
+    hosts => ["https://opensearch:9200"]
+    index => "%{[@metadata][target_index]}-%{+YYYY.MM.dd}"
+    user => "admin"
+    password => "admin"
+    ssl_certificate_verification => false
+  }
+}
+```
+
+## OpenSearch output plugin reference
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `hosts` | -- | Array of OpenSearch endpoints |
+| `index` | `logstash-%{+YYYY.MM.dd}` | Index name pattern |
+| `user` | -- | Basic auth username |
+| `password` | -- | Basic auth password |
+| `ssl_certificate_verification` | `true` | Verify SSL certificates |
+| `template_name` | `logstash` | Index template name |
+| `bulk_size` | `500` | Number of events per bulk request |
+| `retry_max_interval` | `64` | Max seconds between retries |
+| `pipeline` | -- | Ingest pipeline to apply |
+
+## When to use Logstash vs Data Prepper
+
+| Consideration | Logstash | Data Prepper |
+|---------------|----------|--------------|
+| Primary protocol | Beats, TCP, Syslog | OTLP, HTTP |
+| Transform language | Ruby-based filter DSL | YAML pipeline config |
+| Plugin ecosystem | 200+ plugins (inputs, filters, outputs) | Focused on OTel and OpenSearch |
+| OTel integration | Limited (requires plugins) | Native OTLP support |
+| Trace processing | Not designed for traces | Built-in trace analytics |
+| Resource usage | Higher (JVM-based, full pipeline) | Moderate (JVM-based, focused) |
+| Best for | Complex log transformations, legacy systems | OTel-native pipelines, trace/log correlation |
+
+**Recommendation**: Use Data Prepper when your telemetry sources support OpenTelemetry. Use Logstash when you need to ingest from non-OTel sources (syslog, Beats, Kafka), require complex log transformations with Grok patterns, or have existing Logstash pipelines you want to keep.
+
+## Monitoring Logstash
+
+Logstash exposes a monitoring API on port 9600:
+
+```bash
+# Pipeline stats
+curl -s http://localhost:9600/_node/stats/pipelines | jq .
+
+# Check if Logstash is running
+curl -s http://localhost:9600/ | jq '.status'
+
+# Event processing rate
+curl -s http://localhost:9600/_node/stats/pipelines | jq '.pipelines.main.events'
+```
+
+## Related links
+
+- [Infrastructure Monitoring Overview](/opensearch-agentops-website/docs/send-data/infrastructure/)
+- [Fluentd & Fluent Bit](/opensearch-agentops-website/docs/send-data/infrastructure/fluentd/)
+- [Docker](/opensearch-agentops-website/docs/send-data/infrastructure/docker/)
+- [OpenSearch Logstash documentation](https://opensearch.org/docs/latest/tools/logstash/index/) -- Official OpenSearch Logstash plugin reference

--- a/starlight-docs/src/content/docs/send-data/infrastructure/prometheus.md
+++ b/starlight-docs/src/content/docs/send-data/infrastructure/prometheus.md
@@ -1,12 +1,245 @@
 ---
 title: "Prometheus"
-description: "Scrape and remote-write Prometheus metrics"
+description: "Scrape and store Prometheus metrics with OTLP integration and resource attribute promotion"
 ---
 
-# Prometheus
+Prometheus serves as the metrics backend in the OpenSearch Observability Stack. It receives metrics from the OpenTelemetry Collector via the OTLP endpoint and scrapes its own targets. The stack's Prometheus configuration includes OTLP resource attribute promotion, which maps OpenTelemetry resource attributes to Prometheus labels for rich metric querying.
 
-This page is under construction. Content coming soon.
+## Architecture
 
-## Overview
+```mermaid
+graph LR
+    subgraph Applications
+        A1[App 1]
+        A2[App 2]
+    end
 
-Documentation for Prometheus will be added here.
+    subgraph Observability Stack
+        OC[OTel Collector]
+        P[Prometheus :9090]
+        OS[OpenSearch]
+    end
+
+    A1 -->|OTLP| OC
+    A2 -->|OTLP| OC
+    OC -->|OTLP HTTP| P
+    P -->|scrape /metrics| OC
+    P -.->|query| OS
+```
+
+## Prerequisites
+
+- A running OpenSearch Observability Stack
+- OTel Collector configured to export metrics via OTLP HTTP
+- Network access to Prometheus on port 9090
+
+:::tip[Upstream documentation]
+For Prometheus and OpenTelemetry compatibility details, see the [OTel Prometheus compatibility specification](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/) and the [Prometheus configuration reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/).
+:::
+
+## Stack Prometheus configuration
+
+The Observability Stack ships with the following Prometheus configuration:
+
+```yaml
+global:
+  scrape_interval: 60s
+  scrape_timeout: 10s
+  evaluation_interval: 60s
+  external_labels:
+    cluster: observability-stack-dev
+    environment: development
+
+otlp:
+  keep_identifying_resource_attributes: true
+  promote_resource_attributes:
+    - service.instance.id
+    - service.name
+    - service.namespace
+    - service.version
+    - deployment.environment.name
+    - gen_ai.agent.id
+    - gen_ai.agent.name
+    - gen_ai.provider.name
+    - gen_ai.request.model
+    - gen_ai.response.model
+
+storage:
+  tsdb:
+    out_of_order_time_window: 30m
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'otel-collector'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['otel-collector:8888']
+```
+
+### Configuration breakdown
+
+#### Global settings
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `scrape_interval` | `60s` | Default interval between metric scrapes |
+| `scrape_timeout` | `10s` | Timeout for each scrape request |
+| `evaluation_interval` | `60s` | How often recording and alerting rules are evaluated |
+| `external_labels.cluster` | `observability-stack-dev` | Cluster label added to all metrics |
+| `external_labels.environment` | `development` | Environment label added to all metrics |
+
+#### OTLP receiver configuration
+
+The `otlp` section configures how Prometheus receives metrics from the OTel Collector:
+
+- **`keep_identifying_resource_attributes: true`** -- Retains OTel resource attributes as metric labels, preserving the full identity of the metric source.
+- **`promote_resource_attributes`** -- Promotes specific OpenTelemetry resource attributes to first-class Prometheus labels. This allows you to query and aggregate metrics by service name, version, environment, and AI model attributes.
+
+**Promoted attributes:**
+
+| Resource attribute | Use case |
+|-------------------|----------|
+| `service.instance.id` | Distinguish between instances of the same service |
+| `service.name` | Filter metrics by service |
+| `service.namespace` | Group services by namespace |
+| `service.version` | Track metrics across deployments/versions |
+| `deployment.environment.name` | Separate dev/staging/production metrics |
+| `gen_ai.agent.id` | Filter by AI agent instance |
+| `gen_ai.agent.name` | Filter by AI agent name |
+| `gen_ai.provider.name` | Filter by LLM provider (OpenAI, Anthropic, etc.) |
+| `gen_ai.request.model` | Filter by requested model |
+| `gen_ai.response.model` | Filter by actual model used in response |
+
+#### Storage configuration
+
+The `out_of_order_time_window: 30m` setting allows Prometheus to accept samples that arrive up to 30 minutes out of order. This is important for OTLP ingestion because the OTel Collector may batch and send metrics with slight delays.
+
+#### Scrape configs
+
+The default configuration scrapes two targets:
+
+1. **`prometheus`** -- Prometheus self-monitoring metrics at `localhost:9090`
+2. **`otel-collector`** -- OTel Collector internal metrics at `otel-collector:8888`, scraped every 10 seconds for near-real-time collector health monitoring
+
+## OTel Collector metrics export
+
+Configure the OTel Collector to send metrics to Prometheus via the OTLP HTTP exporter:
+
+```yaml
+exporters:
+  otlphttp/prometheus:
+    endpoint: http://prometheus:9090/api/v1/otlp
+    tls:
+      insecure: true
+```
+
+The Collector sends metrics to the `/api/v1/otlp` endpoint, which Prometheus processes using its native OTLP receiver. This is the preferred method over Prometheus remote write because it preserves OpenTelemetry resource attributes.
+
+## Add custom scrape targets
+
+To scrape additional targets, extend the `scrape_configs` section:
+
+```yaml
+scrape_configs:
+  # Existing configs...
+
+  - job_name: 'my-application'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['my-app:8080']
+    metrics_path: /metrics
+
+  - job_name: 'node-exporter'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: 'kubernetes-pods'
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: (.+)
+        replacement: ${1}
+```
+
+## Remote write from external Prometheus
+
+If you have an existing Prometheus instance, you can forward metrics to the stack's Prometheus using remote write:
+
+```yaml
+# In your external Prometheus config
+remote_write:
+  - url: http://your-stack-prometheus:9090/api/v1/write
+    queue_config:
+      max_samples_per_send: 5000
+      batch_send_deadline: 5s
+```
+
+## Query examples
+
+Once metrics are flowing, query them using PromQL:
+
+```promql
+# CPU usage by service
+rate(process_cpu_seconds_total{service_name="my-app"}[5m])
+
+# Request rate by AI model
+rate(gen_ai_client_operation_duration_count{gen_ai_request_model="gpt-4"}[5m])
+
+# Memory usage by environment
+process_resident_memory_bytes{deployment_environment_name="production"}
+
+# OTel Collector throughput
+rate(otelcol_exporter_sent_metric_points_total[5m])
+```
+
+Note that Prometheus converts OTel resource attribute names to label names by replacing dots with underscores (e.g., `service.name` becomes `service_name`).
+
+## When to use Prometheus vs OpenSearch for metrics
+
+| Consideration | Prometheus | OpenSearch |
+|---------------|-----------|------------|
+| Query language | PromQL (optimized for time-series) | PPL, SQL, DQL |
+| Retention | Typically 15-90 days | Long-term storage |
+| Cardinality | Best for low-to-medium cardinality | Handles high cardinality well |
+| Alerting | Built-in Alertmanager integration | OpenSearch alerting plugin |
+| Dashboards | Grafana, built-in UI | OpenSearch Dashboards |
+| Use case | Real-time monitoring, alerting | Historical analysis, correlation with logs/traces |
+
+**Recommendation**: Use Prometheus for real-time metrics, alerting, and operational dashboards. Use OpenSearch for long-term metric storage, cross-signal correlation (metrics + logs + traces), and historical analysis.
+
+## Verify metrics ingestion
+
+1. Check that Prometheus is receiving OTLP metrics:
+
+```bash
+curl -s http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | {job: .labels.job, health: .health}'
+```
+
+2. Verify promoted resource attributes appear as labels:
+
+```bash
+curl -s 'http://localhost:9090/api/v1/label/service_name/values' | jq .
+```
+
+3. Check the OTel Collector scrape target health:
+
+```bash
+curl -s 'http://localhost:9090/api/v1/query?query=up{job="otel-collector"}' | jq '.data.result[0].value[1]'
+```
+
+## Related links
+
+- [Infrastructure Monitoring Overview](/opensearch-agentops-website/docs/send-data/infrastructure/)
+- [Docker](/opensearch-agentops-website/docs/send-data/infrastructure/docker/)
+- [Kubernetes](/opensearch-agentops-website/docs/send-data/infrastructure/kubernetes/)
+- [OTel Prometheus compatibility](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/) -- Prometheus and OpenMetrics compatibility spec
+- [Prometheus configuration reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) -- Official Prometheus configuration docs

--- a/starlight-docs/src/content/docs/send-data/opentelemetry/auto-instrumentation.md
+++ b/starlight-docs/src/content/docs/send-data/opentelemetry/auto-instrumentation.md
@@ -1,12 +1,244 @@
 ---
 title: "Auto-Instrumentation"
-description: "Zero-code instrumentation for popular frameworks and languages"
+description: "Zero-code instrumentation for popular frameworks and languages using OpenTelemetry agents"
 ---
 
-# Auto-Instrumentation
+Auto-instrumentation adds observability to your application without code changes. OpenTelemetry provides language-specific agents and hooks that intercept framework calls (HTTP servers, database clients, message queues) and automatically generate traces, metrics, and logs.
 
-This page is under construction. Content coming soon.
+This is the fastest way to start sending telemetry to the observability stack.
 
-## Overview
+## Prerequisites
 
-Documentation for Auto-Instrumentation will be added here.
+- The observability stack running with the OTel Collector accepting OTLP on ports 4317 (gRPC) and 4318 (HTTP)
+- The target application using a supported framework
+
+:::tip[Upstream documentation]
+For a complete overview of zero-code instrumentation across all languages, see the [OpenTelemetry zero-code instrumentation documentation](https://opentelemetry.io/docs/zero-code/).
+:::
+
+## Environment Variables
+
+All OTel auto-instrumentation agents share a common set of environment variables:
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | Collector endpoint (gRPC default) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | Transport protocol (`grpc` or `http/protobuf`) |
+| `OTEL_SERVICE_NAME` | `payment-service` | Logical service name shown in dashboards |
+| `OTEL_RESOURCE_ATTRIBUTES` | `service.version=1.2.0,deployment.environment=prod` | Comma-separated key=value resource attributes |
+| `OTEL_TRACES_SAMPLER` | `parentbased_traceidratio` | Sampler type (see [Sampling](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/)) |
+| `OTEL_TRACES_SAMPLER_ARG` | `0.1` | Sampler argument (e.g., 10% sample rate) |
+| `OTEL_LOGS_EXPORTER` | `otlp` | Log exporter (`otlp` or `none`) |
+| `OTEL_METRICS_EXPORTER` | `otlp` | Metrics exporter (`otlp` or `none`) |
+
+Set these variables before starting your application. They apply to every language below.
+
+## Python
+
+Install the OpenTelemetry Python packages and auto-instrumentation libraries:
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install
+```
+
+The `opentelemetry-bootstrap` command detects installed libraries (Flask, Django, requests, SQLAlchemy, etc.) and installs their corresponding instrumentation packages.
+
+Run your application with the `opentelemetry-instrument` wrapper:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_SERVICE_NAME="order-service"
+
+opentelemetry-instrument python app.py
+```
+
+For frameworks with their own runners:
+
+```bash
+opentelemetry-instrument flask run
+opentelemetry-instrument gunicorn app:app --workers 4
+opentelemetry-instrument uvicorn app:app --host 0.0.0.0
+```
+
+### Supported Libraries
+
+Common auto-instrumented Python libraries include: Flask, Django, FastAPI, requests, httpx, urllib3, SQLAlchemy, psycopg2, redis, celery, grpcio, boto3, and Kafka.
+
+## Java
+
+Download the OpenTelemetry Java agent JAR:
+
+```bash
+curl -L -o opentelemetry-javaagent.jar \
+  https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+```
+
+Attach the agent using the `-javaagent` JVM flag:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_SERVICE_NAME="checkout-service"
+
+java -javaagent:opentelemetry-javaagent.jar -jar app.jar
+```
+
+The agent automatically instruments Spring Boot, JAX-RS, JDBC, Hibernate, Kafka, gRPC, Netty, Servlet, and 100+ other libraries.
+
+### Configuration via System Properties
+
+Java agent settings can also be passed as system properties:
+
+```bash
+java -javaagent:opentelemetry-javaagent.jar \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -Dotel.service.name=checkout-service \
+  -Dotel.resource.attributes=service.version=2.1.0 \
+  -jar app.jar
+```
+
+## Node.js
+
+Install the OpenTelemetry Node.js packages:
+
+```bash
+npm install @opentelemetry/auto-instrumentations-node \
+            @opentelemetry/sdk-node \
+            @opentelemetry/exporter-trace-otlp-grpc \
+            @opentelemetry/exporter-metrics-otlp-grpc
+```
+
+Use the `--require` flag to load instrumentation before your application code:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_SERVICE_NAME="frontend-service"
+
+node --require @opentelemetry/auto-instrumentations-node/register app.js
+```
+
+This instruments Express, Fastify, Koa, http/https, pg, mysql, redis, ioredis, MongoDB, gRPC, and more.
+
+### TypeScript / ts-node
+
+```bash
+ts-node --require @opentelemetry/auto-instrumentations-node/register app.ts
+```
+
+### ESM Applications
+
+For ES module applications, use the `--import` flag:
+
+```bash
+node --import @opentelemetry/auto-instrumentations-node/register app.mjs
+```
+
+## .NET
+
+Install the OpenTelemetry .NET auto-instrumentation package:
+
+```bash
+# Linux / macOS
+curl -L -o otel-dotnet.sh \
+  https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/otel-dotnet-auto-install.sh
+sh otel-dotnet.sh
+```
+
+Configure and run:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_SERVICE_NAME="inventory-service"
+
+# Source the environment setup script installed by the package
+. $HOME/.otel-dotnet-auto/instrument.sh
+
+dotnet run
+```
+
+The startup hook instruments ASP.NET Core, HttpClient, SqlClient, Entity Framework, gRPC, and other .NET libraries.
+
+### Docker
+
+For containerized .NET applications, add the agent in your Dockerfile:
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+COPY --from=otel/autoinstrumentation-dotnet:latest /autoinstrumentation /otel
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
+ENV CORECLR_PROFILER_PATH=/otel/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
+ENV DOTNET_ADDITIONAL_DEPS=/otel/AdditionalDeps
+ENV DOTNET_SHARED_STORE=/otel/store
+ENV DOTNET_STARTUP_HOOKS=/otel/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll
+ENV OTEL_DOTNET_AUTO_HOME=/otel
+```
+
+## Go
+
+Go auto-instrumentation uses eBPF to instrument applications at the kernel level, without modifying your binary:
+
+```bash
+# Install the Go auto-instrumentation agent
+go install go.opentelemetry.io/auto/cmd/instrumentation@latest
+```
+
+Run the agent alongside your Go application:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_SERVICE_NAME="shipping-service"
+
+# Start your Go application
+./shipping-service &
+APP_PID=$!
+
+# Attach the eBPF instrumentation
+sudo instrumentation -pid $APP_PID
+```
+
+The eBPF agent instruments `net/http`, `google.golang.org/grpc`, and `database/sql`. Since it operates at the kernel level, it requires elevated privileges.
+
+For most Go applications, [manual instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/) is preferred because it provides finer control and does not require root access.
+
+## Verifying Instrumentation
+
+After starting your instrumented application, verify that telemetry is flowing:
+
+1. **Check Collector logs** -- If the `debug` exporter is enabled, you should see spans, metrics, and logs in the Collector stdout.
+
+2. **Send a test request** to your application:
+   ```bash
+   curl http://localhost:8080/api/health
+   ```
+
+3. **Query OpenSearch** for the trace:
+   ```json
+   GET otel-v1-apm-span-*/_search
+   {
+     "query": {
+       "term": { "serviceName": "your-service-name" }
+     }
+   }
+   ```
+
+4. **Open OpenSearch Dashboards** and navigate to the [Services](/opensearch-agentops-website/docs/apm/services/) view to see your application.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| No spans in OpenSearch | Wrong endpoint | Verify `OTEL_EXPORTER_OTLP_ENDPOINT` points to the Collector |
+| Spans appear but no metrics | Metrics exporter disabled | Set `OTEL_METRICS_EXPORTER=otlp` |
+| Missing library spans | Instrumentation not installed | Run `opentelemetry-bootstrap -a install` (Python) or verify agent JAR (Java) |
+| Service name shows "unknown_service" | `OTEL_SERVICE_NAME` not set | Set the environment variable before starting the app |
+| gRPC connection refused | Protocol mismatch | Use port 4317 for gRPC, port 4318 for HTTP |
+
+## Related Links
+
+- [Manual Instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/) -- Add custom spans and metrics
+- [Collector Configuration](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/) -- OTel Collector pipeline setup
+- [Sampling Strategies](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/) -- Control telemetry volume
+- [Applications](/opensearch-agentops-website/docs/send-data/applications/) -- Language-specific application guides
+- [OpenTelemetry zero-code instrumentation](https://opentelemetry.io/docs/zero-code/) -- Official zero-code instrumentation guide
+- [OTel instrumentation registry](https://opentelemetry.io/ecosystem/registry/?component=instrumentation) -- Browse available instrumentation packages

--- a/starlight-docs/src/content/docs/send-data/opentelemetry/collector.md
+++ b/starlight-docs/src/content/docs/send-data/opentelemetry/collector.md
@@ -1,12 +1,342 @@
 ---
 title: "OTel Collector Configuration"
-description: "Configure the OpenTelemetry Collector to export to OpenSearch"
+description: "Configure the OpenTelemetry Collector pipeline for traces, metrics, and logs"
 ---
 
-# OTel Collector Configuration
+The OpenTelemetry Collector is the central routing layer in the observability stack. It receives telemetry from your applications via OTLP, processes it (batching, resource detection, transformations), and exports it to Data Prepper and Prometheus.
 
-This page is under construction. Content coming soon.
+This page walks through the complete Collector configuration used by the stack.
 
-## Overview
+## Prerequisites
 
-Documentation for OTel Collector Configuration will be added here.
+- The observability stack running (OTel Collector, Data Prepper, Prometheus, OpenSearch)
+- Applications configured to send OTLP to the Collector endpoints
+
+:::tip[Upstream documentation]
+For the complete OTel Collector reference, see the [official OpenTelemetry Collector documentation](https://opentelemetry.io/docs/collector/).
+:::
+
+## Full Configuration
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins: ["http://*", "https://*"]
+
+processors:
+  memory_limiter:
+    check_interval: 5s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+  resourcedetection:
+    detectors: [env, system]
+  transform:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - replace_pattern(attributes["url.path"], "\\?.*", "")
+          - replace_pattern(name, "\\?.*", "")
+          - replace_pattern(name, "GET /api/products/[^/]+", "GET /api/products/{productId}")
+          - set(attributes["db_system_name"], attributes["db.system.name"]) where attributes["db.system.name"] != nil
+          - set(attributes["code_function_name"], attributes["code.function.name"]) where attributes["code.function.name"] != nil
+          - set(attributes["user_agent_original"], attributes["user_agent.original"]) where attributes["user_agent.original"] != nil
+          - set(attributes["upstream_cluster_name"], attributes["upstream_cluster.name"]) where attributes["upstream_cluster.name"] != nil
+          - set(attributes["error_type"], attributes["error.type"]) where attributes["error.type"] != nil
+          - set(attributes["app_ads_contextKeys"], attributes["app.ads.contextKeys"]) where attributes["app.ads.contextKeys"] != nil
+          - set(attributes["rpc_system"], attributes["rpc.system"]) where attributes["rpc.system"] != nil
+    log_statements:
+      - context: log
+        statements:
+          - flatten(body, "")
+          - merge_maps(body, body[""], "upsert")
+          - delete_key(body, "")
+          - set(body, Concat([body], ", ")) where IsMap(body)
+
+exporters:
+  debug:
+    verbosity: detailed
+  otlp/opensearch:
+    endpoint: data-prepper:21890
+    tls:
+      insecure: true
+  otlphttp/prometheus:
+    endpoint: http://prometheus:9090/api/v1/otlp
+
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, transform, batch]
+      exporters: [otlp/opensearch, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, batch]
+      exporters: [otlphttp/prometheus, debug]
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, transform, batch]
+      exporters: [otlp/opensearch, debug]
+```
+
+## Receivers
+
+The `otlp` receiver accepts all three telemetry signals over two protocols:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins: ["http://*", "https://*"]
+```
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `grpc.endpoint` | `0.0.0.0:4317` | Accept OTLP gRPC from backend services |
+| `http.endpoint` | `0.0.0.0:4318` | Accept OTLP HTTP from browsers, serverless |
+| `http.cors.allowed_origins` | `["http://*", "https://*"]` | Allow browser-based instrumentation from any origin |
+
+The CORS configuration is permissive by default for development. In production, restrict `allowed_origins` to your application domains.
+
+## Processors
+
+Processors run in the order specified in each pipeline definition. The stack uses four processors:
+
+### memory_limiter
+
+```yaml
+memory_limiter:
+  check_interval: 5s
+  limit_percentage: 80
+  spike_limit_percentage: 25
+```
+
+Prevents the Collector from running out of memory under load. When memory usage exceeds 80%, the Collector starts dropping data. The spike limit reserves 25% headroom for sudden bursts.
+
+Place `memory_limiter` early in the processor chain (after `resourcedetection`) so it can shed load before expensive processing occurs.
+
+### batch
+
+```yaml
+batch:
+  timeout: 10s
+  send_batch_size: 1024
+```
+
+Batches telemetry records before export to reduce the number of outbound requests. A batch is flushed when it reaches 1024 items or 10 seconds have elapsed, whichever comes first.
+
+| Setting | Default | Recommendation |
+|---------|---------|----------------|
+| `timeout` | 200ms | 5-30s for production |
+| `send_batch_size` | 8192 | 512-2048 depending on payload size |
+
+### resourcedetection
+
+```yaml
+resourcedetection:
+  detectors: [env, system]
+```
+
+Automatically populates resource attributes from the runtime environment:
+
+- **`env`** -- Reads `OTEL_RESOURCE_ATTRIBUTES` environment variable
+- **`system`** -- Adds `host.name`, `host.arch`, `os.type`
+
+Additional detectors are available for cloud environments: `aws`, `gcp`, `azure`, `docker`, `kubernetes`.
+
+### transform
+
+The transform processor uses the [OTel Transformation Language (OTTL)](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) to modify telemetry in-flight.
+
+**Trace transformations:**
+
+```yaml
+transform:
+  error_mode: ignore
+  trace_statements:
+    - context: span
+      statements:
+        # Strip query parameters from URL paths and span names
+        - replace_pattern(attributes["url.path"], "\\?.*", "")
+        - replace_pattern(name, "\\?.*", "")
+        # Normalize high-cardinality span names
+        - replace_pattern(name, "GET /api/products/[^/]+", "GET /api/products/{productId}")
+```
+
+Query parameter stripping prevents high-cardinality URL paths from creating excessive unique span names. The product ID normalization collapses `GET /api/products/123`, `GET /api/products/456`, etc. into a single operation name.
+
+**Dotted attribute flattening:**
+
+```yaml
+        # Flatten dotted attribute keys (workaround for data-prepper#5616)
+        - set(attributes["db_system_name"], attributes["db.system.name"]) where attributes["db.system.name"] != nil
+```
+
+OTel semantic convention attributes use dots (e.g., `db.system.name`), but Data Prepper may interpret dots as nested object paths. These statements copy dotted attributes to underscore-delimited equivalents so they are indexed correctly.
+
+**Log transformations:**
+
+```yaml
+  log_statements:
+    - context: log
+      statements:
+        - flatten(body, "")
+        - merge_maps(body, body[""], "upsert")
+        - delete_key(body, "")
+        - set(body, Concat([body], ", ")) where IsMap(body)
+```
+
+These statements normalize structured log bodies. Nested maps are flattened and merged into the top-level body, ensuring consistent indexing in OpenSearch.
+
+## Exporters
+
+### otlp/opensearch
+
+```yaml
+otlp/opensearch:
+  endpoint: data-prepper:21890
+  tls:
+    insecure: true
+```
+
+Sends traces and logs to Data Prepper over OTLP gRPC. Data Prepper then processes and indexes them in OpenSearch. TLS is disabled because the Collector and Data Prepper communicate over a private Docker network.
+
+In production with network exposure, enable TLS:
+
+```yaml
+otlp/opensearch:
+  endpoint: data-prepper:21890
+  tls:
+    cert_file: /certs/collector.crt
+    key_file: /certs/collector.key
+    ca_file: /certs/ca.crt
+```
+
+### otlphttp/prometheus
+
+```yaml
+otlphttp/prometheus:
+  endpoint: http://prometheus:9090/api/v1/otlp
+```
+
+Sends metrics to Prometheus via its native OTLP HTTP endpoint (available since Prometheus 2.47). No conversion or remote-write adapter is needed.
+
+### debug
+
+```yaml
+debug:
+  verbosity: detailed
+```
+
+Logs all exported telemetry to the Collector's stdout. Useful for development and troubleshooting. Remove or set `verbosity: basic` in production.
+
+## Service Pipelines
+
+The `service.pipelines` section wires receivers, processors, and exporters together:
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, transform, batch]
+      exporters: [otlp/opensearch, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, batch]
+      exporters: [otlphttp/prometheus, debug]
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, transform, batch]
+      exporters: [otlp/opensearch, debug]
+```
+
+Note that the **metrics** pipeline does not include the `transform` processor -- metric transformations are not needed for the default setup.
+
+### Collector self-monitoring
+
+```yaml
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
+```
+
+The Collector exposes its own metrics on port 8888 in Prometheus format. Scrape this endpoint to monitor Collector health, queue depths, and export errors.
+
+## Customization Tips
+
+**Add a new receiver** (e.g., Kafka):
+```yaml
+receivers:
+  otlp: ...
+  kafka:
+    brokers: ["kafka:9092"]
+    topic: telemetry
+    encoding: otlp_proto
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, kafka]
+```
+
+**Filter unwanted spans** (e.g., health checks):
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - 'attributes["url.path"] == "/health"'
+        - 'attributes["url.path"] == "/ready"'
+```
+
+**Add tail sampling** at the Collector level (see [Sampling Strategies](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/)):
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 30s
+    policies:
+      - name: errors
+        type: status_code
+        status_code: {status_codes: [ERROR]}
+      - name: slow
+        type: latency
+        latency: {threshold_ms: 5000}
+```
+
+## Related Links
+
+- [OpenTelemetry Overview](/opensearch-agentops-website/docs/send-data/opentelemetry/) -- Signals, protocols, and architecture
+- [Sampling Strategies](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/) -- Head and tail sampling configuration
+- [Data Pipeline](/opensearch-agentops-website/docs/send-data/pipeline/) -- Data Prepper and Prometheus configuration
+- [OpenTelemetry Collector documentation](https://opentelemetry.io/docs/collector/) -- Official Collector configuration reference
+- [Collector contrib components](https://github.com/open-telemetry/opentelemetry-collector-contrib) -- Community receivers, processors, and exporters

--- a/starlight-docs/src/content/docs/send-data/opentelemetry/index.md
+++ b/starlight-docs/src/content/docs/send-data/opentelemetry/index.md
@@ -1,12 +1,123 @@
 ---
 title: "OpenTelemetry"
-description: "Instrument with OpenTelemetry — the recommended approach"
+description: "Understand OpenTelemetry signals, protocols, and how OTel integrates with the observability stack"
 ---
 
-# OpenTelemetry
+[OpenTelemetry](https://opentelemetry.io/) (OTel) is the CNCF standard for generating, collecting, and exporting telemetry data. The OpenSearch Observability Stack uses OpenTelemetry as its primary ingestion interface -- all telemetry flows through OTel SDKs and the OTel Collector before reaching storage backends.
 
-This page is under construction. Content coming soon.
+This section covers the OTel Collector configuration, instrumentation approaches, and sampling strategies.
 
-## Overview
+:::tip[Upstream documentation]
+To learn more about OpenTelemetry concepts and architecture, see [What is OpenTelemetry?](https://opentelemetry.io/docs/what-is-opentelemetry/) on the official OpenTelemetry website.
+:::
 
-Documentation for OpenTelemetry will be added here.
+## Telemetry Signals
+
+OpenTelemetry defines three core signal types:
+
+### Traces
+
+A **trace** represents a single request as it propagates through your system. Each trace is composed of **spans** -- units of work with a start time, duration, status, and parent-child relationships.
+
+Traces answer questions like:
+- Which services handled this request?
+- Where did latency occur?
+- What caused the error?
+
+The stack stores traces in OpenSearch via Data Prepper, indexed in `otel-v1-apm-span-*` indices.
+
+### Metrics
+
+A **metric** is a numerical measurement captured over time. OTel supports counters, histograms, gauges, and exponential histograms.
+
+Metrics answer questions like:
+- What is the request rate for this service?
+- What is the p99 latency?
+- How much memory is the process using?
+
+The stack routes metrics to Prometheus via OTLP HTTP for efficient time-series storage and querying.
+
+### Logs
+
+A **log** is a timestamped text or structured record emitted by an application. OTel logs support trace correlation, meaning each log record can carry a `traceId` and `spanId` to link it to the distributed trace that was active when the log was emitted.
+
+The stack stores logs in OpenSearch via Data Prepper, enabling full-text search and trace-correlated log exploration.
+
+## OTLP Protocol
+
+All three signals are transmitted using the **OpenTelemetry Protocol (OTLP)**, which supports two transports:
+
+| Transport | Endpoint | Encoding | Best For |
+|-----------|----------|----------|----------|
+| gRPC | `http://localhost:4317` | Protobuf | Backend services, high throughput |
+| HTTP | `http://localhost:4318` | Protobuf or JSON | Browsers, serverless, restricted networks |
+
+OTLP is the only protocol you need. Unlike vendor-specific formats (Zipkin, Jaeger, StatsD), OTLP carries all three signals over a single connection, reducing operational complexity.
+
+## Architecture
+
+The following diagram shows how OpenTelemetry components fit into the stack:
+
+```mermaid
+flowchart TD
+    subgraph Application
+        SDK["OTel SDK<br/>(TracerProvider, MeterProvider, LoggerProvider)"]
+        Auto["Auto-Instrumentation<br/>(framework hooks)"]
+        Manual["Manual Instrumentation<br/>(custom spans, metrics)"]
+        Auto --> SDK
+        Manual --> SDK
+    end
+
+    SDK -->|"OTLP"| Collector["OTel Collector"]
+
+    subgraph Collector Pipeline
+        R["Receivers<br/>otlp (4317, 4318)"]
+        P["Processors<br/>batch, memory_limiter,<br/>resourcedetection, transform"]
+        E["Exporters<br/>otlp/opensearch, otlphttp/prometheus"]
+        R --> P --> E
+    end
+
+    Collector --> DP["Data Prepper :21890"]
+    Collector --> Prom["Prometheus :9090"]
+    DP --> OS["OpenSearch"]
+    Prom --> OSD["OpenSearch Dashboards"]
+    OS --> OSD
+```
+
+**Key points:**
+
+1. **SDKs** run in your application process. They create spans, record metrics, and bridge log frameworks.
+2. **Auto-instrumentation** hooks into frameworks and libraries to generate telemetry without code changes.
+3. **Manual instrumentation** lets you add custom spans, attributes, and metrics for business-specific observability.
+4. **The OTel Collector** receives, processes, and exports telemetry. It runs as a standalone service (not embedded in your app).
+5. **Data Prepper** receives traces and logs from the Collector and writes them to OpenSearch indices.
+6. **Prometheus** receives metrics from the Collector via OTLP HTTP.
+
+## Semantic Conventions
+
+OpenTelemetry defines [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) -- standardized attribute names for common concepts. The stack relies on these conventions for its dashboards and visualizations:
+
+| Convention | Prefix | Example Attributes |
+|------------|--------|--------------------|
+| HTTP | `http.*`, `url.*` | `http.request.method`, `url.path`, `http.response.status_code` |
+| Database | `db.*` | `db.system.name`, `db.query.text`, `db.operation.name` |
+| RPC | `rpc.*` | `rpc.system`, `rpc.service`, `rpc.method` |
+| Gen-AI | `gen_ai.*` | `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens` |
+| Service | `service.*` | `service.name`, `service.version`, `service.namespace` |
+
+Using standard attribute names means the APM dashboards, service maps, and agent trace views work out of the box.
+
+## In This Section
+
+- [Collector Configuration](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/) -- Full walkthrough of the OTel Collector pipeline config
+- [Auto-Instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/) -- Zero-code instrumentation for popular languages
+- [Manual Instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/) -- Custom spans, metrics, and logs with the OTel SDK
+- [Sampling Strategies](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/) -- Control data volume with head-based and tail-based sampling
+
+## Related Links
+
+- [Send Data Overview](/opensearch-agentops-website/docs/send-data/) -- Full ingestion architecture
+- [Agent Traces](/opensearch-agentops-website/docs/ai-observability/agent-tracing/) -- AI agent trace visualization
+- [APM Services](/opensearch-agentops-website/docs/apm/services/) -- Service health monitoring
+- [What is OpenTelemetry?](https://opentelemetry.io/docs/what-is-opentelemetry/) -- Official overview of the OpenTelemetry project
+- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/) -- Standard attribute naming reference

--- a/starlight-docs/src/content/docs/send-data/opentelemetry/manual-instrumentation.md
+++ b/starlight-docs/src/content/docs/send-data/opentelemetry/manual-instrumentation.md
@@ -1,12 +1,306 @@
 ---
 title: "Manual Instrumentation"
-description: "Add custom spans, metrics, and logs with the OTel SDK"
+description: "Add custom spans, metrics, and logs with the OpenTelemetry SDK"
 ---
 
-# Manual Instrumentation
+Manual instrumentation gives you full control over what telemetry your application produces. Use it to add custom spans for business logic, record application-specific metrics, and emit structured logs with trace correlation.
 
-This page is under construction. Content coming soon.
+Manual instrumentation complements [auto-instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/). Auto-instrumentation covers framework-level operations (HTTP handlers, database calls), while manual instrumentation covers your domain logic.
 
-## Overview
+## When to Use Manual Instrumentation
 
-Documentation for Manual Instrumentation will be added here.
+- Tracking business operations (order placement, payment processing, AI agent invocations)
+- Adding custom attributes to spans (user ID, tenant, feature flags)
+- Recording application-specific metrics (queue depth, cache hit ratio, token usage)
+- Emitting structured logs correlated with the active trace
+- Instrumenting code that auto-instrumentation does not cover
+
+## Prerequisites
+
+- OTel SDK installed for your language
+- The observability stack running with the OTel Collector on ports 4317/4318
+
+:::tip[Upstream documentation]
+For language-specific manual instrumentation guides, see the [OpenTelemetry manual instrumentation documentation](https://opentelemetry.io/docs/concepts/instrumentation/manual/).
+:::
+
+## Provider Setup
+
+Before creating telemetry, configure the three provider types. This example uses Python with OTLP gRPC exporters:
+
+```python
+from opentelemetry import trace, metrics, _logs
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+# Shared resource identifies this service
+resource = Resource.create({
+    "service.name": "weather-agent",
+    "service.version": "1.0.0",
+    "deployment.environment": "production",
+})
+
+# Traces
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter())
+)
+trace.set_tracer_provider(tracer_provider)
+
+# Metrics
+metric_reader = PeriodicExportingMetricReader(
+    OTLPMetricExporter(),
+    export_interval_millis=10000,
+)
+meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
+
+# Logs
+logger_provider = LoggerProvider(resource=resource)
+logger_provider.add_log_record_processor(
+    BatchLogRecordProcessor(OTLPLogExporter())
+)
+_logs.set_logger_provider(logger_provider)
+```
+
+The `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable configures the exporter endpoint. If not set, it defaults to `http://localhost:4317`.
+
+## Creating Spans
+
+Spans represent units of work. Every span has a name, start/end time, status, and optional attributes.
+
+### Basic Span
+
+```python
+tracer = trace.get_tracer("my-app", "1.0.0")
+
+with tracer.start_as_current_span("process-order") as span:
+    span.set_attribute("order.id", order_id)
+    span.set_attribute("order.total", total_amount)
+    result = process_order(order_id)
+    span.set_attribute("order.status", result.status)
+```
+
+### Nested Spans
+
+Child spans automatically inherit the parent context:
+
+```python
+with tracer.start_as_current_span("handle-request"):
+    # This span is a child of "handle-request"
+    with tracer.start_as_current_span("validate-input"):
+        validate(request)
+
+    with tracer.start_as_current_span("execute-query"):
+        results = db.query(sql)
+```
+
+### Span Kinds
+
+Set the span kind to describe the role of the operation:
+
+```python
+from opentelemetry.trace import SpanKind
+
+# Client calling an external service
+with tracer.start_as_current_span("call-payment-api", kind=SpanKind.CLIENT) as span:
+    span.set_attribute("rpc.system", "http")
+    response = http_client.post(payment_url, data=payload)
+
+# Internal processing (default)
+with tracer.start_as_current_span("compute-discount", kind=SpanKind.INTERNAL):
+    discount = calculate_discount(user)
+```
+
+| Kind | Use Case |
+|------|----------|
+| `SERVER` | Handling an incoming request |
+| `CLIENT` | Making an outgoing request |
+| `PRODUCER` | Enqueueing a message |
+| `CONSUMER` | Processing a message from a queue |
+| `INTERNAL` | Internal operation (default) |
+
+### Error Recording
+
+```python
+from opentelemetry.trace import StatusCode
+
+with tracer.start_as_current_span("risky-operation") as span:
+    try:
+        result = do_something()
+    except Exception as e:
+        span.set_status(StatusCode.ERROR, str(e))
+        span.record_exception(e)
+        raise
+```
+
+## Recording Metrics
+
+Metrics capture numerical measurements over time.
+
+```python
+meter = metrics.get_meter("my-app", "1.0.0")
+
+# Counter: monotonically increasing value
+request_counter = meter.create_counter(
+    name="http.server.request.count",
+    description="Number of HTTP requests",
+    unit="1",
+)
+
+# Histogram: distribution of values
+latency_histogram = meter.create_histogram(
+    name="http.server.request.duration",
+    description="Request latency",
+    unit="ms",
+)
+
+# Up-down counter: value that can increase and decrease
+active_connections = meter.create_up_down_counter(
+    name="http.server.active_requests",
+    description="Number of active requests",
+    unit="1",
+)
+
+# Record values with attributes
+request_counter.add(1, {"http.request.method": "GET", "http.route": "/api/orders"})
+latency_histogram.record(42.5, {"http.request.method": "GET", "http.route": "/api/orders"})
+active_connections.add(1)
+```
+
+### Observable Gauges
+
+For metrics that are read on demand (e.g., system stats, queue depth):
+
+```python
+def get_queue_depth(options):
+    yield metrics.Observation(value=queue.size(), attributes={"queue.name": "orders"})
+
+meter.create_observable_gauge(
+    name="queue.depth",
+    callbacks=[get_queue_depth],
+    description="Current queue depth",
+    unit="1",
+)
+```
+
+## Structured Logging with Trace Correlation
+
+OTel logs bridge your existing logging framework with the telemetry pipeline, adding trace and span IDs automatically.
+
+### Python (logging module)
+
+```python
+import logging
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+# Enable trace context injection into log records
+LoggingInstrumentor().instrument(set_logging_format=True)
+
+logger = logging.getLogger(__name__)
+
+with tracer.start_as_current_span("process-payment"):
+    logger.info("Processing payment for order %s", order_id)
+    # Log record automatically includes traceId, spanId, traceFlags
+```
+
+### Direct OTel Log Emission
+
+```python
+from opentelemetry._logs import get_logger, SeverityNumber
+
+otel_logger = get_logger("my-app", "1.0.0")
+
+otel_logger.emit(
+    _logs.LogRecord(
+        severity_number=SeverityNumber.INFO,
+        body="Payment processed successfully",
+        attributes={"order.id": order_id, "payment.method": "card"},
+    )
+)
+```
+
+## Gen-AI Semantic Conventions
+
+For AI/LLM agent applications, OpenTelemetry defines [Gen-AI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) that the stack's Agent Traces UI relies on.
+
+### Key Span Patterns
+
+```python
+# Top-level agent invocation (SpanKind.CLIENT)
+with tracer.start_as_current_span("invoke_agent", kind=SpanKind.CLIENT) as span:
+    span.set_attribute("gen_ai.system", "openai")
+    span.set_attribute("gen_ai.request.model", "gpt-4o")
+
+    # Tool execution within the agent (SpanKind.INTERNAL)
+    with tracer.start_as_current_span("execute_tool", kind=SpanKind.INTERNAL) as tool_span:
+        tool_span.set_attribute("gen_ai.tool.name", "get_weather")
+        tool_span.set_attribute("gen_ai.tool.call.id", call_id)
+        result = get_weather(location)
+```
+
+### Gen-AI Attribute Reference
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `gen_ai.system` | string | AI provider (`openai`, `anthropic`, `bedrock`) |
+| `gen_ai.request.model` | string | Model identifier (`gpt-4o`, `claude-sonnet-4-20250514`) |
+| `gen_ai.response.model` | string | Actual model used in response |
+| `gen_ai.request.temperature` | float | Sampling temperature |
+| `gen_ai.request.max_tokens` | int | Maximum tokens requested |
+| `gen_ai.usage.input_tokens` | int | Tokens in the prompt |
+| `gen_ai.usage.output_tokens` | int | Tokens in the completion |
+| `gen_ai.tool.name` | string | Name of the tool/function called |
+| `gen_ai.tool.call.id` | string | Unique identifier for the tool call |
+| `gen_ai.prompt` | string | The prompt sent (use with caution in production) |
+| `gen_ai.completion` | string | The completion returned (use with caution in production) |
+
+### Metrics for AI Applications
+
+```python
+meter = metrics.get_meter("ai-agent", "1.0.0")
+
+token_counter = meter.create_counter(
+    name="gen_ai.client.token.usage",
+    description="Token usage by model",
+    unit="token",
+)
+
+token_counter.add(
+    prompt_tokens,
+    {"gen_ai.system": "openai", "gen_ai.request.model": "gpt-4o", "gen_ai.token.type": "input"},
+)
+token_counter.add(
+    completion_tokens,
+    {"gen_ai.system": "openai", "gen_ai.request.model": "gpt-4o", "gen_ai.token.type": "output"},
+)
+```
+
+## Graceful Shutdown
+
+Always flush pending telemetry before your application exits:
+
+```python
+tracer_provider.shutdown()
+meter_provider.shutdown()
+logger_provider.shutdown()
+```
+
+For long-running services, register these in a shutdown hook (e.g., `atexit`, signal handler, or framework shutdown event).
+
+## Related Links
+
+- [Auto-Instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/) -- Zero-code instrumentation setup
+- [Collector Configuration](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/) -- Pipeline processing and export
+- [Agent Traces](/opensearch-agentops-website/docs/ai-observability/agent-tracing/) -- Visualize AI agent traces
+- [Sampling Strategies](/opensearch-agentops-website/docs/send-data/opentelemetry/sampling/) -- Control data volume
+- [OpenTelemetry manual instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/manual/) -- Official manual instrumentation concepts
+- [OpenTelemetry API reference](https://opentelemetry.io/docs/specs/otel/) -- OTel specification and API reference

--- a/starlight-docs/src/content/docs/send-data/opentelemetry/sampling.md
+++ b/starlight-docs/src/content/docs/send-data/opentelemetry/sampling.md
@@ -1,12 +1,378 @@
 ---
 title: "Sampling Strategies"
-description: "Head-based and tail-based sampling for controlling data volume"
+description: "Control telemetry volume with head-based and tail-based sampling"
 ---
 
-# Sampling Strategies
+Sampling determines which traces are recorded and exported. In production environments with high request volumes, exporting every trace is often impractical -- it increases storage costs, network bandwidth, and processing load. Sampling lets you retain a representative subset of traces while ensuring important traces (errors, slow requests) are always captured.
 
-This page is under construction. Content coming soon.
+## Prerequisites
 
-## Overview
+- Familiarity with the [OTel Collector configuration](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/)
+- Understanding of [OpenTelemetry traces](/opensearch-agentops-website/docs/send-data/opentelemetry/)
 
-Documentation for Sampling Strategies will be added here.
+## Head-Based vs Tail-Based Sampling
+
+| Aspect | Head-Based | Tail-Based |
+|--------|-----------|------------|
+| Decision point | At trace start (first span) | After trace completes |
+| Information available | Trace ID, parent context | All spans, status, duration |
+| Resource cost | Low (per-span check) | High (must buffer full traces) |
+| Implementation | SDK-level | Collector-level |
+| Can filter by outcome | No | Yes (errors, latency, etc.) |
+
+**Head-based sampling** decides at the moment a trace begins whether to record it. The decision is fast and cheap but cannot account for what happens later in the trace.
+
+**Tail-based sampling** waits until all spans in a trace have arrived, then decides based on the complete picture. This is more powerful but requires buffering entire traces in the Collector.
+
+## Sampling and APM Service Maps
+
+:::caution
+Data Prepper's `otel_apm_service_map` processor needs **all traces** to compute RED metrics (Rate, Errors, Duration) and build accurate service maps. If you sample at the SDK or Collector level, the service map will be incomplete and RED metrics will be inaccurate.
+
+**Recommendation:** For APM users, keep the SDK sampler at `always_on` and let Data Prepper handle sampling after service map processing.
+
+The recommended data flow for APM users:
+
+```
+SDK (always_on) → Collector (no sampling) → Data Prepper (service map → sample) → OpenSearch
+```
+:::
+
+## Sampling with the OTel SDK
+
+Head-based samplers run inside the OTel SDK in your application process.
+
+### AlwaysOn / AlwaysOff
+
+```bash
+# Record everything (default)
+export OTEL_TRACES_SAMPLER="always_on"
+
+# Record nothing
+export OTEL_TRACES_SAMPLER="always_off"
+```
+
+### TraceIdRatioBased
+
+Samples a fixed percentage of traces based on the trace ID. The decision is deterministic -- the same trace ID always produces the same decision, ensuring consistency across services.
+
+```bash
+# Sample 10% of traces
+export OTEL_TRACES_SAMPLER="traceidratio"
+export OTEL_TRACES_SAMPLER_ARG="0.1"
+```
+
+In code (Python):
+
+```python
+from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+sampler = TraceIdRatioBased(rate=0.1)  # 10%
+tracer_provider = TracerProvider(sampler=sampler, resource=resource)
+```
+
+| Rate | Traces Kept | Use Case |
+|------|-------------|----------|
+| `1.0` | 100% | Development, low-traffic services |
+| `0.1` | 10% | Medium-traffic production |
+| `0.01` | 1% | High-traffic production |
+| `0.001` | 0.1% | Very high-traffic (>10K rps) |
+
+### ParentBased
+
+Wraps another sampler and respects the parent span's sampling decision. This ensures that if a parent service decided to sample a trace, all downstream services also sample it, maintaining trace completeness.
+
+```bash
+# Sample 10% of root spans; follow parent decision for child spans
+export OTEL_TRACES_SAMPLER="parentbased_traceidratio"
+export OTEL_TRACES_SAMPLER_ARG="0.1"
+```
+
+In code (Python):
+
+```python
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+
+sampler = ParentBased(root=TraceIdRatioBased(rate=0.1))
+tracer_provider = TracerProvider(sampler=sampler, resource=resource)
+```
+
+**ParentBased is the recommended default for most deployments.** It prevents broken traces where some services sample a request and others do not.
+
+The `parentbased_traceidratio` sampler works as follows:
+
+1. If the incoming request has a sampled parent context, **always sample** (keep the trace).
+2. If the incoming request has an unsampled parent context, **never sample** (drop the trace).
+3. If there is no parent context (root span), apply the `TraceIdRatioBased` decision.
+
+For a deeper dive, see the [OpenTelemetry sampling concepts documentation](https://opentelemetry.io/docs/concepts/sampling/).
+
+## Sampling in the OTel Collector
+
+Tail-based sampling runs in the OTel Collector using the `tail_sampling` processor. It buffers complete traces and applies policy-based decisions.
+
+### Basic Configuration
+
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 30s
+    num_traces: 100000
+    expected_new_traces_per_sec: 1000
+    policies:
+      - name: keep-errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      - name: keep-slow
+        type: latency
+        latency:
+          threshold_ms: 5000
+      - name: sample-rest
+        type: probabilistic
+        probabilistic:
+          sampling_percentage: 10
+```
+
+### Policy Types
+
+| Policy | Description | Example |
+|--------|-------------|---------|
+| `status_code` | Keep traces with specific status codes | Keep all errors |
+| `latency` | Keep traces exceeding a latency threshold | Keep traces > 5s |
+| `probabilistic` | Random percentage sampling | Keep 10% of remaining |
+| `string_attribute` | Match a span attribute value | Keep traces from `payment-service` |
+| `rate_limiting` | Cap traces per second | Max 100 traces/sec |
+| `always_sample` | Keep all traces (used with composite) | Fallback policy |
+| `composite` | Combine multiple policies with rates | Complex multi-rule sampling |
+
+### Policy Evaluation
+
+Policies are evaluated in order. A trace is kept if **any** policy matches. The first matching policy determines the outcome. Use this to build an "always keep errors and slow traces, sample the rest" strategy:
+
+1. `keep-errors` -- Always keep error traces
+2. `keep-slow` -- Always keep slow traces
+3. `sample-rest` -- Probabilistically sample everything else
+
+### Composite Sampling
+
+For fine-grained control, use the `composite` policy to combine sub-policies with rate limits:
+
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 30s
+    policies:
+      - name: composite-policy
+        type: composite
+        composite:
+          max_total_spans_per_second: 5000
+          policy_order: [errors-policy, slow-policy, general-policy]
+          composite_sub_policy:
+            - name: errors-policy
+              type: status_code
+              status_code:
+                status_codes: [ERROR]
+            - name: slow-policy
+              type: latency
+              latency:
+                threshold_ms: 2000
+            - name: general-policy
+              type: always_sample
+          rate_allocation:
+            - policy: errors-policy
+              percent: 50
+            - policy: slow-policy
+              percent: 30
+            - policy: general-policy
+              percent: 20
+```
+
+This allocates 50% of the span budget to errors, 30% to slow traces, and 20% to a random sample of everything else.
+
+### Adding Tail Sampling to the Pipeline
+
+Add the `tail_sampling` processor to the traces pipeline in your Collector configuration:
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, tail_sampling, batch]
+      exporters: [otlp/opensearch, debug]
+```
+
+Place `tail_sampling` before `batch` -- it needs to see individual spans before they are grouped.
+
+### Resource Considerations
+
+Tail-based sampling requires buffering complete traces in memory:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `decision_wait` | 30s | Time to wait for all spans in a trace |
+| `num_traces` | 50000 | Maximum traces held in memory |
+| `expected_new_traces_per_sec` | 0 | Used to pre-allocate memory |
+
+Increase `decision_wait` if your traces have long-running spans (e.g., batch jobs). Increase `num_traces` proportionally with traffic volume. Monitor the Collector's memory usage via its Prometheus metrics endpoint (port 8888).
+
+For more on Collector data transformation, see the [OTel Collector transforming telemetry guide](https://opentelemetry.io/docs/collector/transforming-telemetry/).
+
+## Sampling in Data Prepper
+
+Data Prepper provides its own sampling processors that run after trace analytics processing. This is the recommended sampling point when using APM features.
+
+### Aggregate processor for rate-based sampling
+
+The `aggregate` processor can perform rate-based sampling after the service map processor has seen all traces. This ensures RED metrics and service maps are computed from the full trace data before any traces are dropped.
+
+```yaml
+pipeline:
+  source:
+    otel_trace_source:
+      ssl: false
+  processor:
+    - otel_apm_service_map:
+        window_duration: 180
+    - aggregate:
+        identification_keys: ["traceId"]
+        action:
+          tail_sampler:
+            percent: 20
+            wait_period: "10s"
+            condition: '/status == "ERROR" or /durationInNanos > 5000000000'
+  sink:
+    - opensearch:
+        hosts: ["https://opensearch:9200"]
+        index_type: trace-analytics-raw
+```
+
+### Pipeline placement
+
+Sampling processors MUST come AFTER `otel_apm_service_map` in the pipeline. The service map processor needs to see all traces to compute accurate RED metrics. Once service map data is computed, you can safely sample before writing to OpenSearch. Placing a sampling processor before the service map processor will result in incomplete service maps and inaccurate rate, error, and duration calculations.
+
+### Full pipeline with sampling
+
+A complete Data Prepper configuration with trace analytics and sampling:
+
+```yaml
+otel-trace-pipeline:
+  source:
+    otel_trace_source:
+      ssl: false
+  processor:
+    - otel_apm_service_map:
+        window_duration: 180
+    - aggregate:
+        identification_keys: ["traceId"]
+        action:
+          tail_sampler:
+            percent: 20
+            wait_period: "10s"
+            condition: '/status == "ERROR" or /durationInNanos > 5000000000'
+  sink:
+    - opensearch:
+        hosts: ["https://opensearch:9200"]
+        index_type: trace-analytics-raw
+
+service-map-pipeline:
+  source:
+    pipeline:
+      name: "otel-trace-pipeline"
+  processor:
+    - service_map:
+  sink:
+    - opensearch:
+        hosts: ["https://opensearch:9200"]
+        index_type: trace-analytics-service-map
+```
+
+## Production Recommendations
+
+### APM users: Sample in Data Prepper
+
+If you use APM service maps or the Services dashboard, sample in Data Prepper rather than at the SDK or Collector level. SDK-level and Collector-level sampling will discard traces before Data Prepper can process them, leading to incomplete service maps and inaccurate RED metrics.
+
+- Keep the SDK sampler at `always_on`
+- Skip Collector-level sampling
+- Let Data Prepper handle sampling after the `otel_apm_service_map` processor
+
+### Low Traffic (< 100 rps)
+
+Use `always_on` (the default). Keep all traces for full visibility.
+
+```bash
+export OTEL_TRACES_SAMPLER="always_on"
+```
+
+### Medium Traffic (100-1000 rps)
+
+Use `parentbased_traceidratio` at the SDK level:
+
+```bash
+export OTEL_TRACES_SAMPLER="parentbased_traceidratio"
+export OTEL_TRACES_SAMPLER_ARG="0.1"
+```
+
+### High Traffic (> 1000 rps)
+
+Combine head-based and tail-based sampling:
+
+1. **SDK**: Set `parentbased_traceidratio` to 0.05 (5%) to reduce Collector load
+2. **Collector**: Add `tail_sampling` to keep all errors and slow traces from the 5% that reach the Collector
+
+If you are using APM service maps, prefer Data Prepper sampling instead. Set the SDK to `always_on` and configure the `aggregate` processor in Data Prepper to sample after the service map processor has computed RED metrics.
+
+```bash
+# SDK-level
+export OTEL_TRACES_SAMPLER="parentbased_traceidratio"
+export OTEL_TRACES_SAMPLER_ARG="0.05"
+```
+
+```yaml
+# Collector-level
+processors:
+  tail_sampling:
+    decision_wait: 30s
+    policies:
+      - name: errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      - name: slow
+        type: latency
+        latency:
+          threshold_ms: 3000
+      - name: baseline
+        type: probabilistic
+        probabilistic:
+          sampling_percentage: 20
+```
+
+### Metrics and Logs
+
+Sampling applies only to traces. Metrics are pre-aggregated and do not benefit from sampling. Logs can be filtered at the Collector using the `filter` processor rather than sampled.
+
+### Choosing a sampling strategy
+
+```
+1. Do you use APM Service Maps?
+   → Yes: Sample in Data Prepper (after service map processing)
+   → No: Continue to step 2
+
+2. What is your traffic volume?
+   → Low (< 100 rps): Use always_on (no sampling needed)
+   → Medium (100-1000 rps): Use parentbased_traceidratio at SDK level
+   → High (> 1000 rps): Combine SDK ratio sampling + Collector tail sampling
+```
+
+## Related Links
+
+- [OpenTelemetry Sampling Concepts](https://opentelemetry.io/docs/concepts/sampling/) -- Upstream OTel sampling documentation
+- [OTel Collector Transforming Telemetry](https://opentelemetry.io/docs/collector/transforming-telemetry/) -- Collector processing reference
+- [Collector Configuration](/opensearch-agentops-website/docs/send-data/opentelemetry/collector/) -- Full pipeline config walkthrough
+- [Auto-Instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/auto-instrumentation/) -- Set sampler via environment variables
+- [Manual Instrumentation](/opensearch-agentops-website/docs/send-data/opentelemetry/manual-instrumentation/) -- Configure samplers in code
+- [Data Prepper Pipeline](/opensearch-agentops-website/docs/send-data/data-pipeline/data-prepper/) -- Data Prepper configuration
+- [Send Data Overview](/opensearch-agentops-website/docs/send-data/) -- Ingestion architecture


### PR DESCRIPTION
### PR Summary

  - Add comprehensive send-data documentation covering 25 pages: application instrumentation (Python, Node.js, Java, Go, .NET, Ruby, Browser), infrastructure monitoring (Docker, Kubernetes, AWS, Prometheus, Logstash, Fluentd), OpenTelemetry concepts (Collector, auto/manual instrumentation, sampling), and data
  pipeline (Data Prepper, batching, ingest API)
  - Add upstream OpenTelemetry documentation links across all pages with :::tip callouts and Related links sections referencing opentelemetry.io, Prometheus, Fluent, and OpenSearch official docs
  - Restructure sampling page into SDK / Collector / Data Prepper sections with APM service map callout
  - Enable Mermaid diagram support in Starlight docs