### PR TITLE
 Replace fictional agentops SDK with real opensearch-genai-sdk-py examples and clean up homepage

### DIFF
--- a/.kiro/specs/opensearch-agentops-website/design.md
+++ b/.kiro/specs/opensearch-agentops-website/design.md
@@ -441,7 +441,7 @@ const features = [
     visual: 'code',
     visualContent: {
       language: 'python',
-      code: `from agentops import trace\n\n@trace\ndef my_llm_call():\n    ...`,
+      code: `from opentelemetry import trace\n\n@trace\ndef my_llm_call():\n    ...`,
     },
     imagePosition: 'right',
   },

--- a/src/components/Features.unit.test.ts
+++ b/src/components/Features.unit.test.ts
@@ -191,7 +191,7 @@ describe('Features Component - Unit Tests', () => {
                   </div>
                   <span class="text-xs text-slate-500 font-mono">python</span>
                 </div>
-                <pre class="p-6 overflow-x-auto"><code class="text-sm font-mono text-slate-300">from agentops import trace
+                <pre class="p-6 overflow-x-auto"><code class="text-sm font-mono text-slate-300">from opentelemetry import trace
 
 @trace
 def my_llm_call(prompt):
@@ -231,7 +231,7 @@ def my_llm_call(prompt):
 
       expect(pre).toBeTruthy();
       expect(code).toBeTruthy();
-      expect(code?.textContent).toContain('from agentops import trace');
+      expect(code?.textContent).toContain('from opentelemetry import trace');
       expect(code?.textContent).toContain('@trace');
     });
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,75 +1,26 @@
 ---
-// Footer component for OpenSearch AgentOps marketing website
-// Displays four-column layout with links, logo, copyright, and social media
-
-interface FooterLink {
-  label: string;
-  href: string;
-}
-
-interface FooterColumn {
-  title: string;
-  links: FooterLink[];
-}
-
-const footerColumns: FooterColumn[] = [
-  {
-    title: 'Product',
-    links: [
-      { label: 'Features', href: '#features' },
-      { label: 'Pricing', href: '#pricing' },
-      { label: 'Changelog', href: '/changelog' },
-      { label: 'Roadmap', href: '/roadmap' },
-    ],
-  },
-  {
-    title: 'Resources',
-    links: [
-      { label: 'Documentation', href: 'https://docs.opensearch.org' },
-      { label: 'API Reference', href: 'https://docs.opensearch.org/api' },
-      { label: 'Tutorials', href: '/tutorials' },
-      { label: 'Blog', href: '/blog' },
-    ],
-  },
-  {
-    title: 'Company',
-    links: [
-      { label: 'About', href: '/about' },
-      { label: 'Careers', href: '/careers' },
-      { label: 'Contact', href: '/contact' },
-      { label: 'Press', href: '/press' },
-    ],
-  },
-  {
-    title: 'Legal',
-    links: [
-      { label: 'Privacy', href: '/privacy' },
-      { label: 'Terms', href: '/terms' },
-      { label: 'Security', href: '/security' },
-      { label: 'GDPR', href: '/gdpr' },
-    ],
-  },
-];
+// Footer component for OpenSearch Observability Stack marketing website
+// Displays logo, copyright, and social media links
 
 const socialLinks = [
   {
     platform: 'GitHub',
-    url: 'https://github.com/opensearch-project/agentops',
+    url: 'https://github.com/opensearch-project/observability-stack',
     icon: 'M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z',
   },
   {
-    platform: 'Twitter',
-    url: 'https://twitter.com/opensearch',
+    platform: 'X (Twitter)',
+    url: 'https://x.com/OpenSearchProj',
     icon: 'M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z',
   },
   {
-    platform: 'Discord',
-    url: 'https://discord.gg/opensearch',
-    icon: 'M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z',
+    platform: 'Slack',
+    url: 'https://opensearch.org/slack/',
+    icon: 'M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z',
   },
   {
     platform: 'LinkedIn',
-    url: 'https://linkedin.com/company/opensearch',
+    url: 'https://www.linkedin.com/company/opensearch-project/posts/?feedView=all',
     icon: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
   },
 ];
@@ -79,31 +30,8 @@ const currentYear = new Date().getFullYear();
 
 <footer class="bg-slate-950 border-t border-slate-800 py-12">
   <div class="container mx-auto px-6">
-    <!-- Four-column layout -->
-    <nav class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12" aria-label="Footer navigation">
-      {footerColumns.map((column) => (
-        <div class="footer-column">
-          <h3 class="text-white font-semibold text-lg mb-4">{column.title}</h3>
-          <ul class="space-y-3">
-            {column.links.map((link) => (
-              <li>
-                <a
-                  href={link.href}
-                  class="text-slate-400 hover:text-white transition-colors text-sm"
-                  target={link.href.startsWith('http') ? '_blank' : undefined}
-                  rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                >
-                  {link.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
-    </nav>
-
     <!-- Bottom section with logo, copyright, and social links -->
-    <div class="border-t border-slate-800 pt-8">
+    <div>
       <div class="flex flex-col md:flex-row items-center justify-between gap-6">
         <!-- Logo and Copyright -->
         <div class="flex flex-col md:flex-row items-center gap-4">
@@ -155,4 +83,3 @@ const currentYear = new Date().getFullYear();
     }
   }
 </style>
-

--- a/src/components/Footer.unit.test.ts
+++ b/src/components/Footer.unit.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for Footer component
- * Requirements: 13.1, 13.2, 13.3, 13.4, 13.5, 13.6
+ * Requirements: 13.1, 13.6
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -18,297 +18,33 @@ describe('Footer Component - Unit Tests', () => {
   });
 
   /**
-   * Test: All four columns render
+   * Test: No footer column nav exists (columns were removed)
    * Requirements: 13.1
    */
-  describe('Footer Columns Rendering', () => {
-    it('should render all four footer columns', () => {
+  describe('Footer Columns Removed', () => {
+    it('should not render any footer columns', () => {
       const footerHTML = `
         <footer id="footer">
-          <div class="footer-column">
-            <h3>Product</h3>
-          </div>
-          <div class="footer-column">
-            <h3>Resources</h3>
-          </div>
-          <div class="footer-column">
-            <h3>Company</h3>
-          </div>
-          <div class="footer-column">
-            <h3>Legal</h3>
+          <div class="container mx-auto px-6">
+            <div>
+              <div class="flex flex-col md:flex-row items-center justify-between gap-6">
+                <div class="flex flex-col md:flex-row items-center gap-4">
+                  <a href="/"><span>Observability Stack</span></a>
+                  <p id="copyright-notice">© 2026 OpenSearch - Observability Stack. All rights reserved.</p>
+                </div>
+                <div id="social-links"></div>
+              </div>
+            </div>
           </div>
         </footer>
       `;
-      
+
       container.innerHTML = footerHTML;
       const columns = container.querySelectorAll('.footer-column');
+      const nav = container.querySelector('nav[aria-label="Footer navigation"]');
 
-      expect(columns).toBeTruthy();
-      expect(columns.length).toBe(4);
-    });
-
-    it('should render Product column with correct title', () => {
-      const footerHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Product</h3>
-          </div>
-        </footer>
-      `;
-      
-      container.innerHTML = footerHTML;
-      const heading = container.querySelector('h3');
-
-      expect(heading).toBeTruthy();
-      expect(heading?.textContent).toBe('Product');
-    });
-
-    it('should render Resources column with correct title', () => {
-      const footerHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Resources</h3>
-          </div>
-        </footer>
-      `;
-      
-      container.innerHTML = footerHTML;
-      const heading = container.querySelector('h3');
-
-      expect(heading).toBeTruthy();
-      expect(heading?.textContent).toBe('Resources');
-    });
-
-    it('should render Company column with correct title', () => {
-      const footerHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Company</h3>
-          </div>
-        </footer>
-      `;
-      
-      container.innerHTML = footerHTML;
-      const heading = container.querySelector('h3');
-
-      expect(heading).toBeTruthy();
-      expect(heading?.textContent).toBe('Company');
-    });
-
-    it('should render Legal column with correct title', () => {
-      const footerHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Legal</h3>
-          </div>
-        </footer>
-      `;
-      
-      container.innerHTML = footerHTML;
-      const heading = container.querySelector('h3');
-
-      expect(heading).toBeTruthy();
-      expect(heading?.textContent).toBe('Legal');
-    });
-  });
-
-  /**
-   * Test: Each column has correct links
-   * Requirements: 13.2, 13.3, 13.4, 13.5
-   */
-  describe('Product Column Links', () => {
-    beforeEach(() => {
-      const productColumnHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Product</h3>
-            <ul>
-              <li><a href="#features">Features</a></li>
-              <li><a href="#pricing">Pricing</a></li>
-              <li><a href="/changelog">Changelog</a></li>
-              <li><a href="/roadmap">Roadmap</a></li>
-            </ul>
-          </div>
-        </footer>
-      `;
-      container.innerHTML = productColumnHTML;
-    });
-
-    it('should have Features link', () => {
-      const link = container.querySelector('a[href="#features"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Features');
-    });
-
-    it('should have Pricing link', () => {
-      const link = container.querySelector('a[href="#pricing"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Pricing');
-    });
-
-    it('should have Changelog link', () => {
-      const link = container.querySelector('a[href="/changelog"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Changelog');
-    });
-
-    it('should have Roadmap link', () => {
-      const link = container.querySelector('a[href="/roadmap"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Roadmap');
-    });
-
-    it('should have all four Product links', () => {
-      const links = container.querySelectorAll('a');
-      expect(links.length).toBe(4);
-    });
-  });
-
-  describe('Resources Column Links', () => {
-    beforeEach(() => {
-      const resourcesColumnHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Resources</h3>
-            <ul>
-              <li><a href="https://docs.opensearch.org" target="_blank" rel="noopener noreferrer">Documentation</a></li>
-              <li><a href="https://docs.opensearch.org/api" target="_blank" rel="noopener noreferrer">API Reference</a></li>
-              <li><a href="/tutorials">Tutorials</a></li>
-              <li><a href="/blog">Blog</a></li>
-            </ul>
-          </div>
-        </footer>
-      `;
-      container.innerHTML = resourcesColumnHTML;
-    });
-
-    it('should have Documentation link as external', () => {
-      const link = container.querySelector('a[href="https://docs.opensearch.org"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Documentation');
-      expect(link?.getAttribute('target')).toBe('_blank');
-      expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
-    });
-
-    it('should have API Reference link as external', () => {
-      const link = container.querySelector('a[href="https://docs.opensearch.org/api"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('API Reference');
-      expect(link?.getAttribute('target')).toBe('_blank');
-      expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
-    });
-
-    it('should have Tutorials link', () => {
-      const link = container.querySelector('a[href="/tutorials"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Tutorials');
-    });
-
-    it('should have Blog link', () => {
-      const link = container.querySelector('a[href="/blog"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Blog');
-    });
-
-    it('should have all four Resources links', () => {
-      const links = container.querySelectorAll('a');
-      expect(links.length).toBe(4);
-    });
-  });
-
-  describe('Company Column Links', () => {
-    beforeEach(() => {
-      const companyColumnHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Company</h3>
-            <ul>
-              <li><a href="/about">About</a></li>
-              <li><a href="/careers">Careers</a></li>
-              <li><a href="/contact">Contact</a></li>
-              <li><a href="/press">Press</a></li>
-            </ul>
-          </div>
-        </footer>
-      `;
-      container.innerHTML = companyColumnHTML;
-    });
-
-    it('should have About link', () => {
-      const link = container.querySelector('a[href="/about"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('About');
-    });
-
-    it('should have Careers link', () => {
-      const link = container.querySelector('a[href="/careers"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Careers');
-    });
-
-    it('should have Contact link', () => {
-      const link = container.querySelector('a[href="/contact"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Contact');
-    });
-
-    it('should have Press link', () => {
-      const link = container.querySelector('a[href="/press"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Press');
-    });
-
-    it('should have all four Company links', () => {
-      const links = container.querySelectorAll('a');
-      expect(links.length).toBe(4);
-    });
-  });
-
-  describe('Legal Column Links', () => {
-    beforeEach(() => {
-      const legalColumnHTML = `
-        <footer>
-          <div class="footer-column">
-            <h3>Legal</h3>
-            <ul>
-              <li><a href="/privacy">Privacy</a></li>
-              <li><a href="/terms">Terms</a></li>
-              <li><a href="/security">Security</a></li>
-              <li><a href="/gdpr">GDPR</a></li>
-            </ul>
-          </div>
-        </footer>
-      `;
-      container.innerHTML = legalColumnHTML;
-    });
-
-    it('should have Privacy link', () => {
-      const link = container.querySelector('a[href="/privacy"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Privacy');
-    });
-
-    it('should have Terms link', () => {
-      const link = container.querySelector('a[href="/terms"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Terms');
-    });
-
-    it('should have Security link', () => {
-      const link = container.querySelector('a[href="/security"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('Security');
-    });
-
-    it('should have GDPR link', () => {
-      const link = container.querySelector('a[href="/gdpr"]');
-      expect(link).toBeTruthy();
-      expect(link?.textContent).toBe('GDPR');
-    });
-
-    it('should have all four Legal links', () => {
-      const links = container.querySelectorAll('a');
-      expect(links.length).toBe(4);
+      expect(columns.length).toBe(0);
+      expect(nav).toBeNull();
     });
   });
 
@@ -322,16 +58,16 @@ describe('Footer Component - Unit Tests', () => {
         <footer>
           <a href="/">
             <svg class="w-8 h-8"></svg>
-            <span>AgentOps</span>
+            <span>Observability Stack</span>
           </a>
         </footer>
       `;
-      
+
       container.innerHTML = footerHTML;
       const logoLink = container.querySelector('a[href="/"]');
 
       expect(logoLink).toBeTruthy();
-      expect(logoLink?.querySelector('span')?.textContent).toBe('AgentOps');
+      expect(logoLink?.querySelector('span')?.textContent).toBe('Observability Stack');
     });
 
     it('should have logo SVG element', () => {
@@ -342,7 +78,7 @@ describe('Footer Component - Unit Tests', () => {
           </a>
         </footer>
       `;
-      
+
       container.innerHTML = footerHTML;
       const svg = container.querySelector('svg');
 
@@ -354,16 +90,16 @@ describe('Footer Component - Unit Tests', () => {
       const currentYear = new Date().getFullYear();
       const footerHTML = `
         <footer>
-          <p id="copyright-notice">© ${currentYear} OpenSearch AgentOps. All rights reserved.</p>
+          <p id="copyright-notice">© ${currentYear} OpenSearch - Observability Stack. All rights reserved.</p>
         </footer>
       `;
-      
+
       container.innerHTML = footerHTML;
       const copyright = container.querySelector('#copyright-notice');
 
       expect(copyright).toBeTruthy();
       expect(copyright?.textContent).toContain(currentYear.toString());
-      expect(copyright?.textContent).toContain('OpenSearch AgentOps');
+      expect(copyright?.textContent).toContain('OpenSearch');
       expect(copyright?.textContent).toContain('All rights reserved');
     });
 
@@ -371,10 +107,10 @@ describe('Footer Component - Unit Tests', () => {
       const currentYear = new Date().getFullYear();
       const footerHTML = `
         <footer>
-          <p id="copyright-notice">© ${currentYear} OpenSearch AgentOps. All rights reserved.</p>
+          <p id="copyright-notice">© ${currentYear} OpenSearch - Observability Stack. All rights reserved.</p>
         </footer>
       `;
-      
+
       container.innerHTML = footerHTML;
       const copyright = container.querySelector('#copyright-notice');
 
@@ -391,16 +127,16 @@ describe('Footer Component - Unit Tests', () => {
       const socialLinksHTML = `
         <footer>
           <div id="social-links">
-            <a href="https://github.com/opensearch-project/agentops" target="_blank" rel="noopener noreferrer" aria-label="Visit our GitHub page">
+            <a href="https://github.com/opensearch-project/observability-stack" target="_blank" rel="noopener noreferrer" aria-label="Visit our GitHub page">
               <svg class="w-6 h-6"></svg>
             </a>
-            <a href="https://twitter.com/opensearch" target="_blank" rel="noopener noreferrer" aria-label="Visit our Twitter page">
+            <a href="https://x.com/OpenSearchProj" target="_blank" rel="noopener noreferrer" aria-label="Visit our X (Twitter) page">
               <svg class="w-6 h-6"></svg>
             </a>
-            <a href="https://discord.gg/opensearch" target="_blank" rel="noopener noreferrer" aria-label="Visit our Discord page">
+            <a href="https://opensearch.org/slack/" target="_blank" rel="noopener noreferrer" aria-label="Visit our Slack page">
               <svg class="w-6 h-6"></svg>
             </a>
-            <a href="https://linkedin.com/company/opensearch" target="_blank" rel="noopener noreferrer" aria-label="Visit our LinkedIn page">
+            <a href="https://www.linkedin.com/company/opensearch-project/posts/?feedView=all" target="_blank" rel="noopener noreferrer" aria-label="Visit our LinkedIn page">
               <svg class="w-6 h-6"></svg>
             </a>
           </div>
@@ -410,31 +146,31 @@ describe('Footer Component - Unit Tests', () => {
     });
 
     it('should have GitHub social link', () => {
-      const link = container.querySelector('a[href="https://github.com/opensearch-project/agentops"]');
+      const link = container.querySelector('a[href="https://github.com/opensearch-project/observability-stack"]');
       expect(link).toBeTruthy();
       expect(link?.getAttribute('target')).toBe('_blank');
       expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
       expect(link?.getAttribute('aria-label')).toContain('GitHub');
     });
 
-    it('should have Twitter social link', () => {
-      const link = container.querySelector('a[href="https://twitter.com/opensearch"]');
+    it('should have X (Twitter) social link', () => {
+      const link = container.querySelector('a[href="https://x.com/OpenSearchProj"]');
       expect(link).toBeTruthy();
       expect(link?.getAttribute('target')).toBe('_blank');
       expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
-      expect(link?.getAttribute('aria-label')).toContain('Twitter');
+      expect(link?.getAttribute('aria-label')).toContain('X (Twitter)');
     });
 
-    it('should have Discord social link', () => {
-      const link = container.querySelector('a[href="https://discord.gg/opensearch"]');
+    it('should have Slack social link', () => {
+      const link = container.querySelector('a[href="https://opensearch.org/slack/"]');
       expect(link).toBeTruthy();
       expect(link?.getAttribute('target')).toBe('_blank');
       expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
-      expect(link?.getAttribute('aria-label')).toContain('Discord');
+      expect(link?.getAttribute('aria-label')).toContain('Slack');
     });
 
     it('should have LinkedIn social link', () => {
-      const link = container.querySelector('a[href="https://linkedin.com/company/opensearch"]');
+      const link = container.querySelector('a[href="https://www.linkedin.com/company/opensearch-project/posts/?feedView=all"]');
       expect(link).toBeTruthy();
       expect(link?.getAttribute('target')).toBe('_blank');
       expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
@@ -461,48 +197,6 @@ describe('Footer Component - Unit Tests', () => {
   });
 
   /**
-   * Test: Responsive layout structure
-   * Requirements: 13.1
-   */
-  describe('Responsive Layout', () => {
-    it('should have grid layout classes for responsive design', () => {
-      const footerHTML = `
-        <footer>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
-            <div class="footer-column"></div>
-            <div class="footer-column"></div>
-            <div class="footer-column"></div>
-            <div class="footer-column"></div>
-          </div>
-        </footer>
-      `;
-      
-      container.innerHTML = footerHTML;
-      const grid = container.querySelector('.grid');
-
-      expect(grid).toBeTruthy();
-      expect(grid?.classList.contains('grid-cols-1')).toBe(true);
-      expect(grid?.classList.contains('md:grid-cols-2')).toBe(true);
-      expect(grid?.classList.contains('lg:grid-cols-4')).toBe(true);
-    });
-
-    it('should have proper semantic footer element', () => {
-      const footerHTML = `
-        <footer id="footer">
-          <div>Content</div>
-        </footer>
-      `;
-      
-      container.innerHTML = footerHTML;
-      const footer = container.querySelector('footer');
-
-      expect(footer).toBeTruthy();
-      expect(footer?.tagName).toBe('FOOTER');
-      expect(footer?.getAttribute('id')).toBe('footer');
-    });
-  });
-
-  /**
    * Test: Footer styling and structure
    * Requirements: 13.1, 13.6
    */
@@ -512,7 +206,7 @@ describe('Footer Component - Unit Tests', () => {
         <footer class="bg-slate-950 border-t border-slate-800">
         </footer>
       `;
-      
+
       container.innerHTML = footerHTML;
       const footer = container.querySelector('footer');
 
@@ -527,7 +221,7 @@ describe('Footer Component - Unit Tests', () => {
           </div>
         </footer>
       `;
-      
+
       container.innerHTML = footerHTML;
       const footer = container.querySelector('footer');
       const containerDiv = footer?.querySelector('.container');
@@ -537,21 +231,19 @@ describe('Footer Component - Unit Tests', () => {
       expect(containerDiv?.classList.contains('px-6')).toBe(true);
     });
 
-    it('should have border separator for bottom section', () => {
+    it('should have proper semantic footer element', () => {
       const footerHTML = `
-        <footer>
-          <div class="border-t border-slate-800 pt-8">
-          </div>
+        <footer id="footer">
+          <div>Content</div>
         </footer>
       `;
-      
-      container.innerHTML = footerHTML;
-      const bottomSection = container.querySelector('.border-t');
 
-      expect(bottomSection).toBeTruthy();
-      expect(bottomSection?.classList.contains('border-slate-800')).toBe(true);
-      expect(bottomSection?.classList.contains('pt-8')).toBe(true);
+      container.innerHTML = footerHTML;
+      const footer = container.querySelector('footer');
+
+      expect(footer).toBeTruthy();
+      expect(footer?.tagName).toBe('FOOTER');
+      expect(footer?.getAttribute('id')).toBe('footer');
     });
   });
 });
-

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -175,7 +175,7 @@ import { CyclingTagline } from './CyclingTagline';
             <span class="text-xs text-slate-400 font-semibold uppercase tracking-wide">Quick Start</span>
             <button 
               class="copy-button px-3 py-1 text-xs bg-slate-800 hover:bg-slate-700 text-slate-300 hover:text-white rounded transition-colors"
-              data-copy="curl -fsSL https://raw.githubusercontent.com/opensearch-project/agentops/main/install.sh | bash"
+              data-copy="curl -fsSL https://raw.githubusercontent.com/opensearch-project/observability-stack/main/install.sh | bash"
               aria-label="Copy command"
             >
               <span class="copy-text">Copy</span>
@@ -183,7 +183,7 @@ import { CyclingTagline } from './CyclingTagline';
             </button>
           </div>
           <code class="text-sm text-cyan-400 font-mono block">
-            <span class="text-slate-500">$</span> curl -fsSL https://raw.githubusercontent.com/opensearch-project/agentops/main/install.sh | bash
+            <span class="text-slate-500">$</span> curl -fsSL https://raw.githubusercontent.com/opensearch-project/observability-stack/main/install.sh | bash
           </code>
           <p class="text-xs text-slate-500 mt-2">Works everywhere. Installs everything. You're welcome. 🔥</p>
         </div>

--- a/src/components/IntegrationPathsTabs.tsx
+++ b/src/components/IntegrationPathsTabs.tsx
@@ -18,21 +18,25 @@ const tabs: Tab[] = [
     id: 'quick',
     label: 'Quickest',
     timing: '5 min',
-    title: 'Pre-Instrumented Framework',
-    description: 'Zero configuration. Just import and go. Perfect for getting started fast.',
+    title: 'GenAI SDK',
+    description: 'One-line setup with automatic OpenTelemetry instrumentation. Decorators for agents, tools, and workflows.',
     language: 'python',
-    code: `from agentops import Client
+    code: `from opensearch_genai_sdk_py import register, agent, tool
 
-# One line initialization
-agentops.init(api_key="your_key")
+# One-line setup — configures OTEL pipeline automatically
+register(service_name="my-app")
 
-# Your existing code works as-is
-def my_agent_function(prompt):
-    response = llm.generate(prompt)
-    return response
+@tool(name="get_weather")
+def get_weather(city: str) -> dict:
+    return {"city": city, "temp": 22, "condition": "sunny"}
+
+@agent(name="weather_assistant")
+def assistant(query: str) -> str:
+    data = get_weather("Paris")
+    return f"{data['condition']}, {data['temp']}C"
 
 # Automatic OTEL traces, metrics, and logs
-result = my_agent_function("Hello AI")`,
+result = assistant("What's the weather?")`,
     benefits: [
       'Zero configuration required',
       'Automatic instrumentation of popular frameworks',
@@ -51,11 +55,11 @@ result = my_agent_function("Hello AI")`,
     code: `from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from agentops.exporters import AgentOpsExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
-# Configure OTEL with Observability Stack exporter
+# Configure OTEL with Observability Stack
 provider = TracerProvider()
-exporter = AgentOpsExporter(api_key="your_key")
+exporter = OTLPSpanExporter(endpoint="http://localhost:4317")
 provider.add_span_processor(BatchSpanProcessor(exporter))
 trace.set_tracer_provider(provider)
 
@@ -64,10 +68,9 @@ tracer = trace.get_tracer(__name__)
 
 with tracer.start_as_current_span("agent_task"):
     response = llm.generate(prompt)
-    # Full control over span attributes
     span = trace.get_current_span()
-    span.set_attribute("llm.model", "gpt-4")
-    span.set_attribute("llm.tokens", 150)`,
+    span.set_attribute("gen_ai.request.model", "gpt-4")
+    span.set_attribute("gen_ai.usage.output_tokens", 150)`,
     benefits: [
       'Standard OTEL APIs - no vendor lock-in',
       'Full control over spans and attributes',
@@ -84,13 +87,12 @@ with tracer.start_as_current_span("agent_task"):
     description: 'Already using OTEL? Just point your exporter to Observability Stack. Keep your existing setup.',
     language: 'python',
     code: `from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from agentops.exporters import AgentOpsExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
 # Add Observability Stack as an additional exporter
 # Keep your existing OTEL configuration
-exporter = AgentOpsExporter(
-    endpoint="https://api.agentops.ai/v1/traces",
-    api_key="your_key"
+exporter = OTLPSpanExporter(
+    endpoint="http://localhost:4317"
 )
 
 # Add to your existing trace provider

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -8,7 +8,6 @@ interface NavItem {
 
 const navigationItems: NavItem[] = [
   { label: 'Features', href: '#features', isExternal: false },
-  { label: 'Use Cases', href: '#use-cases', isExternal: false },
   { label: 'Why OTEL', href: '#why-otel', isExternal: false },
   { label: 'Docs', href: `${import.meta.env.BASE_URL}/docs/`, isExternal: false },
 ];
@@ -25,8 +24,8 @@ const navigationItems: NavItem[] = [
         </a>
       </div>
 
-      <!-- Desktop Navigation -->
-      <div class="hidden md:flex items-center space-x-10">
+      <!-- Desktop Navigation + GitHub -->
+      <div class="hidden md:flex items-center space-x-6">
         {navigationItems.map((item) => (
           <a
             href={item.href}
@@ -37,10 +36,6 @@ const navigationItems: NavItem[] = [
             {item.label}
           </a>
         ))}
-      </div>
-
-      <!-- Desktop CTAs -->
-      <div class="hidden md:flex items-center space-x-4">
         <a
           href="https://github.com/opensearch-project/observability-stack"
           target="_blank"

--- a/src/components/OpenSource.astro
+++ b/src/components/OpenSource.astro
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const {
-  githubUrl = 'https://github.com/opensearch-project/agentops',
+  githubUrl = 'https://github.com/opensearch-project/observability-stack',
   stars = 2500,
   forks = 180,
   contributors = 45,

--- a/src/components/OpenSource.unit.test.ts
+++ b/src/components/OpenSource.unit.test.ts
@@ -166,12 +166,12 @@ describe('OpenSource Component - Unit Tests', () => {
         <section id="open-source">
           <div class="flex flex-col sm:flex-row gap-4">
             <a 
-              href="https://github.com/opensearch-project/agentops"
+              href="https://github.com/opensearch-project/observability-stack"
               target="_blank"
               rel="noopener noreferrer"
               class="px-8 py-4 bg-slate-800 hover:bg-slate-700 text-white font-semibold rounded-lg"
               data-analytics="cta_view_github"
-              data-github-url="https://github.com/opensearch-project/agentops"
+              data-github-url="https://github.com/opensearch-project/observability-stack"
             >
               <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"></svg>
               View on GitHub
@@ -193,7 +193,7 @@ describe('OpenSource Component - Unit Tests', () => {
     it('should have correct GitHub URL', () => {
       const githubButton = container.querySelector('[data-analytics="cta_view_github"]');
 
-      expect(githubButton?.getAttribute('href')).toBe('https://github.com/opensearch-project/agentops');
+      expect(githubButton?.getAttribute('href')).toBe('https://github.com/opensearch-project/observability-stack');
     });
 
     it('should open in new tab', () => {
@@ -458,7 +458,7 @@ describe('OpenSource Component - Unit Tests', () => {
           <div class="flex flex-col items-center gap-6">
             <div class="flex flex-col sm:flex-row gap-4">
               <a 
-                href="https://github.com/opensearch-project/agentops"
+                href="https://github.com/opensearch-project/observability-stack"
                 data-analytics="cta_view_github"
               >
                 View on GitHub

--- a/src/components/QuickWin.astro
+++ b/src/components/QuickWin.astro
@@ -23,18 +23,21 @@
           <span class="text-xs text-slate-500">Python</span>
         </div>
         <div class="p-6 overflow-x-auto">
-          <pre class="text-sm font-mono"><code class="language-python"><span class="text-purple-400">from</span> <span class="text-blue-300">agentops</span> <span class="text-purple-400">import</span> <span class="text-blue-300">Client</span>
+          <pre class="text-sm font-mono"><code class="language-python"><span class="text-purple-400">from</span> <span class="text-blue-300">opensearch_genai_sdk_py</span> <span class="text-purple-400">import</span> <span class="text-blue-300">register</span>, <span class="text-blue-300">agent</span>, <span class="text-blue-300">tool</span>
 
-<span class="text-slate-500"># Initialize with one line</span>
-<span class="text-blue-300">agentops</span>.<span class="text-yellow-300">init</span>(<span class="text-orange-300">api_key</span>=<span class="text-green-400">"your_key"</span>)
+<span class="text-yellow-300">register</span>(<span class="text-orange-300">service_name</span>=<span class="text-green-400">"my-app"</span>)
 
-<span class="text-slate-500"># Your existing code works as-is</span>
-<span class="text-purple-400">def</span> <span class="text-yellow-300">process_request</span>(<span class="text-orange-300">prompt</span>):
-    <span class="text-blue-300">response</span> = <span class="text-blue-300">llm</span>.<span class="text-yellow-300">generate</span>(<span class="text-orange-300">prompt</span>)
-    <span class="text-purple-400">return</span> <span class="text-blue-300">response</span>
+<span class="text-purple-400">@</span><span class="text-yellow-300">tool</span>(<span class="text-orange-300">name</span>=<span class="text-green-400">"search"</span>)
+<span class="text-purple-400">def</span> <span class="text-yellow-300">search</span>(<span class="text-orange-300">query</span>: <span class="text-blue-300">str</span>) -> <span class="text-blue-300">dict</span>:
+    <span class="text-purple-400">return</span> <span class="text-blue-300">search_api</span>.<span class="text-yellow-300">query</span>(<span class="text-orange-300">query</span>)
+
+<span class="text-purple-400">@</span><span class="text-yellow-300">agent</span>(<span class="text-orange-300">name</span>=<span class="text-green-400">"assistant"</span>)
+<span class="text-purple-400">def</span> <span class="text-yellow-300">assistant</span>(<span class="text-orange-300">prompt</span>):
+    <span class="text-blue-300">data</span> = <span class="text-yellow-300">search</span>(<span class="text-orange-300">prompt</span>)
+    <span class="text-purple-400">return</span> <span class="text-blue-300">llm</span>.<span class="text-yellow-300">generate</span>(<span class="text-orange-300">prompt</span>, <span class="text-orange-300">context</span>=<span class="text-blue-300">data</span>)
 
 <span class="text-slate-500"># Automatic OTEL traces captured</span>
-<span class="text-blue-300">result</span> = <span class="text-yellow-300">process_request</span>(<span class="text-green-400">"Hello AI"</span>)</code></pre>
+<span class="text-blue-300">result</span> = <span class="text-yellow-300">assistant</span>(<span class="text-green-400">"Hello AI"</span>)</code></pre>
         </div>
       </div>
 

--- a/src/components/Responsive.otel.test.ts
+++ b/src/components/Responsive.otel.test.ts
@@ -235,17 +235,16 @@ describe('OTEL Redesign - Responsive Layout Tests', () => {
   });
 
   describe('Footer - Responsive Columns', () => {
-    it('should stack footer columns: 1 mobile, 2 tablet, 4 desktop', () => {
+    it('should use flex layout for responsive footer (columns removed)', () => {
       const footerContent = readFileSync(
         join(process.cwd(), 'src/components/Footer.astro'),
         'utf-8'
       );
 
-      // Check for responsive grid columns
-      expect(footerContent).toContain('grid-cols-1');
-      expect(footerContent).toMatch(/md:grid-cols-2/);
-      expect(footerContent).toMatch(/lg:grid-cols-4/);
-      
+      // Footer uses flex-col/flex-row instead of grid columns (columns were removed)
+      expect(footerContent).toContain('flex-col');
+      expect(footerContent).toContain('md:flex-row');
+
       // Validates: Requirements 9.6, 12.4, 12.5
     });
 

--- a/src/components/Responsive.unit.test.ts
+++ b/src/components/Responsive.unit.test.ts
@@ -157,17 +157,16 @@ describe('Responsive Behavior Unit Tests', () => {
       // Validates: Requirements 16.4
     });
 
-    it('Footer should stack columns vertically on mobile', () => {
+    it('Footer should use flex layout for responsive stacking', () => {
       const footerContent = readFileSync(
         join(process.cwd(), 'src/components/Footer.astro'),
         'utf-8'
       );
 
-      // Check for single column on mobile
-      expect(footerContent).toContain('grid-cols-1');
-      expect(footerContent).toContain('md:grid-cols-2');
-      expect(footerContent).toContain('lg:grid-cols-4');
-      
+      // Footer uses flex-col/flex-row instead of grid columns (columns were removed)
+      expect(footerContent).toContain('flex-col');
+      expect(footerContent).toContain('md:flex-row');
+
       // Validates: Requirements 16.4
     });
 

--- a/starlight-docs/src/content/docs/get-started/index.md
+++ b/starlight-docs/src/content/docs/get-started/index.md
@@ -16,7 +16,7 @@ The OpenSearch Observability Stack is an open-source, OpenTelemetry-native obser
 Run the interactive installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/opensearch-project/agentops/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/opensearch-project/observability-stack/main/install.sh | bash
 ```
 
 The installer TUI guides you through component selection and configuration. Once complete, the stack starts automatically.


### PR DESCRIPTION
 ### Summary

  - Replace all fictional agentops Python SDK examples on the homepage with real `opensearch-genai-sdk-py` API (register(), `@agent`, `@tool` decorators) and standard OpenTelemetry patterns (OTLPSpanExporter, gen_ai.*
  semantic conventions)
  - Update GitHub repo URL from opensearch-project/agentops to opensearch-project/observability-stack
  - Remove "Use Cases" from navigation header and consolidate nav items with GitHub link
  - Simplify Footer component and update Hero copy
  - Update docs get-started page and responsive tests

### Changes

  - QuickWin.astro — Real SDK quick start with register(), @tool, @agent
  - IntegrationPathsTabs.tsx — All 3 tabs updated: GenAI SDK, standard OTEL, and OTLP exporter
  - OpenSource.astro — GitHub URL → opensearch-project/observability-stack
  - Navigation.astro — Remove "Use Cases" nav item, group nav links with GitHub
  - Footer.astro — Simplified layout
  - Hero.astro — Copy updates
  - Tests — Updated to match new SDK references and URLs
